### PR TITLE
Tickets/DM-20127: Improve initialization

### DIFF
--- a/scarlet/fft.py
+++ b/scarlet/fft.py
@@ -212,6 +212,12 @@ class Fourier(object):
         for shape, image_fft in self._fft.items():
             self._fft[shape] *= normalization[indices]
 
+    def update_dtype(self, dtype):
+        if self.image.dtype != dtype:
+            self._image = self._image.astype(dtype)
+            for shape in self._fft:
+                self._fft[shape] = self._fft[shape].astype(dtype)
+
     def sum(self, axis=None):
         return self.image.sum(axis)
 

--- a/scarlet/fft.py
+++ b/scarlet/fft.py
@@ -1,0 +1,263 @@
+import operator
+
+import numpy as np
+from scipy import fftpack
+
+
+def _centered(arr, newshape):
+    """Return the center newshape portion of the array.
+
+    This function is used by `fft_convolve` to remove
+    the zero padded region of the convolution.
+
+    Note: If the array shape is odd and the target is even,
+    the center of `arr` is shifted to the center-right
+    pixel position.
+    This is slightly different than the scipy implementation,
+    which uses the center-left pixel for the array center.
+    The reason for the difference is that we have
+    adopted the convention of `np.fft.fftshift` in order
+    to make sure that changing back and forth from
+    fft standard order (0 frequency and position is
+    in the bottom left) to 0 position in the center.
+    """
+    newshape = np.asarray(newshape)
+    currshape = np.array(arr.shape)
+
+    if not np.all(newshape <= currshape):
+        msg = "arr must be larger than newshape in both dimensions, received {0}, and {1}"
+        raise ValueError(msg.format(arr.shape, newshape))
+
+    startind = (currshape - newshape+1) // 2
+    endind = startind + newshape
+    myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
+
+    return arr[tuple(myslice)]
+
+
+def _pad(arr, newshape, axes=None):
+    """Pad an array to fit into newshape
+
+    Pad `arr` with zeros to fit into newshape,
+    which uses the `np.fft.fftshift` convention of moving
+    the center pixel of `arr` (if `arr.shape` is odd) to
+    the center-right pixel in an even shaped `newshape`.
+    """
+    if axes is None:
+        newshape = np.asarray(newshape)
+        currshape = np.array(arr.shape)
+        dS = newshape - currshape
+        startind = (dS+1) // 2
+        endind = dS - startind
+        pad_width = list(zip(startind, endind))
+    else:
+        # only pad the axes that will be transformed
+        pad_width = [(0, 0) for axis in arr.shape]
+        for a, axis in enumerate(axes):
+            dS = newshape[a] - arr.shape[axis]
+            startind = (dS+1) // 2
+            endind = dS - startind
+            pad_width[axis] = (startind, endind)
+    return np.pad(arr, pad_width, mode="constant")
+
+
+def _get_fft_axes(spectral_axis=0):
+    """Return the axes used for the fft
+
+    Given the dimension that contains spectral information,
+    return the `axes` required by `np.fft.fftn` to only
+    Fourier Transform the spatial dimensions.
+    """
+    if spectral_axis is not None:
+        axes = [0, 1, 2]
+        axes.remove(spectral_axis)
+    else:
+        axes = None
+    return axes
+
+
+def _get_fft_shape(img1, img2, padding=3, spectral_axis=0):
+    """Return the fast fft shapes for each spatial axis
+
+    Given the axis that contains the spectral information
+    (`spectral_axis`), calculate the fast fft shape
+    for each remaining dimension.
+    """
+    shape1 = np.asarray(img1.shape)
+    shape2 = np.asarray(img2.shape)
+    # Make sure the shapes are the same size
+    if len(shape1) != len(shape2):
+        msg = "img1 and img2 must have the same number of dimensions, but got {0} and {1}"
+        raise ValueError(msg.format(len(shape1, len(shape2))))
+    # Set the combined shape based on the total dimensions
+    print("spectral_axis", spectral_axis)
+    if spectral_axis == 0:
+        print("spectral_axis 0")
+        shape = shape1[1:] + shape2[1:]
+    elif spectral_axis == 2:
+        shape = shape1[:-1] + shape2[:-1]
+    elif spectral_axis is None:
+        shape = shape1 + shape2
+    else:
+        raise ValueError("spectral_axis should be 0, 2 or None, got {0}".format(spectral_axis))
+    print("shape is", shape)
+    shape += padding
+    # Use the next fastest shape in each dimension
+    shape = [fftpack.helper.next_fast_len(s) for s in shape]
+    # autograd.numpy.fft does not currently work
+    # if the last dimension is odd
+    while shape[-1] % 2 != 0:
+        shape[-1] += 1
+        shape[-1] = fftpack.helper.next_fast_len(shape[-1])
+    return shape
+
+
+class Fourier(object):
+    """An array that stores its Fourier Transform
+
+    The `Fourier` class is used for images that will make
+    use of their Fourier Transform multiple times.
+    In order to prevent numerical artifacts the same image
+    convolved with different images might require different
+    padding, so the FFT for each different shape is stored
+    in a dictionary.
+    """
+    def __init__(self, image, image_fft=None, spectral_axis=0):
+        """Initialize the object
+
+        Parameters
+        ----------
+        image: array
+            The real space image.
+        image_fft: dict
+            A dictionary of {shape: fft_value} for which each different
+            shape has a precalculated FFT.
+        spectral_axis: int
+            The dimension of the array that contains spectral information.
+            If `spectral_axis` is `None` then there is no spectral axis.
+        """
+        if image_fft is None:
+            self._fft = {}
+        else:
+            self._fft = image_fft
+        self._image = image
+        self._spectral_axis = spectral_axis
+
+    @staticmethod
+    def from_fft(image_fft, fft_shape, image_shape, spectral_axis=0):
+        """Generate a new Fourier object from an FFT dictionary
+
+        If the fft of an image has been generated but not its
+        real space image (for example when creating a convolution kernel),
+        this method can be called to create a new `Fourier` instance
+        from the k-space representation.
+
+        Parameters
+        ----------
+        image_fft: array
+            The FFT of the image.
+        fft_shape: tuple
+            Shape of the image used to generate the FFT.
+            This will be different than `image_fft.shape` if
+            any of the dimensions are odd, since `np.fft.rfft`
+            requires an even number of dimensions (for symmetry),
+            so this tells `np.fft.irfft` how to go from
+            complex k-space to real space.
+        image_shape: tuple
+            The shape of the image *before padding*.
+            This will regenerate the image with the extra
+            padding stripped.
+        spectral_axis: int
+            The dimension of the array that contains spectral information.
+            If `image` only has 2 dimensions then this argument is ignored.
+
+        Returns
+        -------
+        result: `Fourier`
+            A `Fourier` object generated from the FFT.
+        """
+        axes = _get_fft_axes(spectral_axis)
+        image = np.fft.irfftn(image_fft, fft_shape, axes=axes)
+        # Shift the center of the image from the bottom left to the center
+        image = np.fft.fftshift(image)
+        # Trim the image to remove the padding added
+        # to reduce fft artifacts
+        image = _centered(image, image_shape)
+        return Fourier(image, {tuple(fft_shape): image_fft}, spectral_axis)
+
+    @property
+    def image(self):
+        """The real space image"""
+        return self._image
+
+    @property
+    def spectral_axis(self):
+        """The dimension of the image containing spectral information"""
+        return self._spectral_axis
+
+    @property
+    def shape(self):
+        """The shape of the real space image"""
+        return self.image.shape
+
+    def fft(self, fft_shape):
+        """The FFT of an image for a given `fft_shape`
+        """
+        fft_shape = tuple(fft_shape)
+        # If this is the first time calling `fft` for this shape,
+        # generate the FFT.
+        if fft_shape not in self._fft:
+            axes = _get_fft_axes(self.spectral_axis)
+            print("axes:", axes)
+            image = _pad(self.image, fft_shape, axes)
+            print("image shape", image.shape)
+            self._fft[fft_shape] = np.fft.rfftn(np.fft.ifftshift(image, axes), axes=axes)
+        return self._fft[fft_shape]
+
+
+def _kspace_operation(image1, image2, padding, operator, shape):
+    """Combine two images in k-space using a given `operator`"""
+    if image1.spectral_axis != image2.spectral_axis:
+        msg = "Both images must have the same spectral dimension, received {0} and {1}"
+        msg.format(image1.spectral_axis, image2.spectral_axis)
+        raise ValueError(msg)
+    fft_shape = _get_fft_shape(image1.image, image2.image, padding, image1.spectral_axis)
+    convolved_fft = operator(image1.fft(fft_shape), image2.fft(fft_shape))
+    convolved = Fourier.from_fft(convolved_fft, fft_shape, shape, image1.spectral_axis)
+    return convolved
+
+
+def match_psfs(psf1, psf2, padding=3):
+    """Calculate the difference kernel between two psfs
+
+    Parameters
+    ----------
+    psf1: `Fourier`
+        `Fourier` object represeting the psf and it's FFT.
+    psf2: `Fourier`
+        `Fourier` object represeting the psf and it's FFT.
+    padding: int
+        Additional padding to use when generating the FFT
+        to supress artifacts.
+    """
+    if psf1.shape[psf1.spectral_axis] < psf2.shape[psf2.spectral_axis]:
+        shape = psf2.shape
+    else:
+        shape = psf1.shape
+    return _kspace_operation(psf1, psf2, padding, operator.truediv, shape)
+
+
+def convolve(image1, image2, padding=3):
+    """Convolve two images
+
+    Parameters
+    ----------
+    image1: `Fourier`
+        `Fourier` object represeting the image and it's FFT.
+    image2: `Fourier`
+        `Fourier` object represeting the image and it's FFT.
+    padding: int
+        Additional padding to use when generating the FFT
+        to supress artifacts.
+    """
+    return _kspace_operation(image1, image2, padding, operator.mul, image1.shape)

--- a/scarlet/interpolation.py
+++ b/scarlet/interpolation.py
@@ -419,3 +419,39 @@ def sinc2D(y, x):
         2-D sinc evaluated in x and y
     '''
     return np.dot(np.sinc(y), np.sinc(x))
+
+
+def apply_2D_trapezoid_rule(y, x, f, dNy, dNx=None, dy=None, dx=None):
+    """Use the trapezoid rule to integrate over a subsampled function
+
+    2D implementation of the trapezoid rule.
+    See `apply_2D_trapezoid_rule` for a description, with the difference
+    that `f` is a function `f(y,x)`, where we note the c ++`(y,x)` ordering.
+    """
+    # Use the spacing between x values to define the integrated regions
+    if dx is None:
+        dx = x[1] - x[0]
+    if dy is None:
+        dy = y[1] - y[0]
+    if dNx is None:
+        dNx = dNy
+    assert dNy % 2 == 0, "dNy must be even, received {0}".format(dNy)
+    assert dNx % 2 == 0, "dNx must be even, received {0}".format(dNx)
+    assert np.all(np.isclose(x[1:]-x[:-1], x[1] - x[0])), "x must have equal spacing"
+    assert np.all(np.isclose(y[1:]-y[:-1], y[1] - y[0])), "y must have equal spacing"
+
+    # Create the subsampled interval and use it to sample `f`
+    _x = np.linspace(x[0]-dx/2, x[-1]+dx/2, len(x)*dNx+1)
+    _y = np.linspace(y[0]-dy/2, y[-1]+dy/2, len(y)*dNy+1)
+    z = f(_y, _x)
+
+    # Calculate the volume of each sub region
+    dz = 0.4 * (z[:-1, :-1] + z[1:, :-1] + z[:-1, 1:] + z[1:, 1:])
+    volumes = dx * dy * dz / dNy / dNx
+
+    # Sum up the sub regions around each point to
+    # give it the same shape as the original `(y,x)`
+    _dNx = len(_x) // dNx
+    _dNy = len(_y) // dNy
+    volumes = np.array(np.split(np.array(np.split(volumes, _dNx, axis=1)), _dNy, axis=1)).sum(axis=(2, 3))
+    return volumes

--- a/scarlet/observation.py
+++ b/scarlet/observation.py
@@ -104,9 +104,7 @@ class Frame():
             if dtype != psfs.image.dtype:
                 msg = "Dtypes of PSFs and Frame different. Casting PSFs to {}".format(dtype)
                 logger.warning(msg)
-                _psfs = psfs.image.astype(dtype)
-                # Create a new Fourier object with the correct dtype
-                psfs = fft.Fourier(_psfs, axes=(1, 2))
+                psfs.update_dtype(dtype)
 
         self._psfs = psfs
 
@@ -239,8 +237,7 @@ class Observation():
             if type(self.weights) is np.ndarray:
                 self.weights = self.weights.astype(model_frame.dtype)
             if self.frame._psfs is not None:
-                _psfs = self.frame._psfs.image.astype(model_frame.dtype)
-                self.frame._psfs = fft.Fourier(_psfs, axes=(1, 2))
+                self.frame.psfs.update_dtype(model_frame.dtype)
 
         #  channels of model that are represented in this observation
         self._band_slice = slice(None)

--- a/scarlet/observation.py
+++ b/scarlet/observation.py
@@ -2,16 +2,16 @@ import autograd.numpy as np
 from scipy import fftpack
 
 from . import interpolation
-
+from . import fft
 from . import resampling
 
 import logging
 
 logger = logging.getLogger("scarlet.observation")
 
+
 def _centered(arr, newshape):
     """Return the center newshape portion of the array.
-
     This function is used by `fft_convolve` to remove
     the zero padded region of the convolution.
     """
@@ -69,7 +69,6 @@ def sinc_shift_1D(img, shift, axis, fast_size):
     return np.fft.fftshift(np.fft.irfftn(img_shiftfft, [fast_size], axes = [1]), axes = [1])
 
 
-
 class Frame():
     """Spatial and spectral characteristics of the data
 
@@ -94,15 +93,20 @@ class Frame():
         if psfs is None:
             logger.warning('No PSFs specified. Possible, but dangerous!')
         else:
-            assert len(psfs) == 1 or len(psfs) == shape[0], 'PSFs need to have shape (1,Ny,Nx) for Blend and (B,Ny,Nx) for Observation'
+            msg = 'PSFs need to have shape (1,Ny,Nx) for Blend and (B,Ny,Nx) for Observation'
+            assert len(psfs) == 1 or len(psfs) == shape[0], msg
+            if not isinstance(psfs, fft.Fourier):
+                psfs = fft.Fourier(psfs, axes=(1, 2))
             if not np.allclose(psfs.sum(axis=(1, 2)), 1):
                 logger.warning('PSFs not normalized. Normalizing now..')
-                psfs /= psfs.sum(axis=(1, 2))[:, None, None]
+                psfs.normalize()
 
-            if dtype != psfs.dtype:
+            if dtype != psfs.image.dtype:
                 msg = "Dtypes of PSFs and Frame different. Casting PSFs to {}".format(dtype)
                 logger.warning(msg)
-                psfs = psfs.astype(dtype)
+                _psfs = psfs.image.astype(dtype)
+                # Create a new Fourier object with the correct dtype
+                psfs = fft.Fourier(_psfs, axes=(1, 2))
 
         self._psfs = psfs
 
@@ -227,14 +231,16 @@ class Observation():
         """
 
         if self.frame.dtype != model_frame.dtype:
-            msg = "Dtypes of model and observation different. Casting observation to {}".format(model_frame.dtype)
+            msg = "Dtypes of model and observation different. Casting observation to {}"
+            msg = msg.format(model_frame.dtype)
             logger.warning(msg)
             self.frame.dtype = model_frame.dtype
             self.images = self.images.astype(model_frame.dtype)
             if type(self.weights) is np.ndarray:
                 self.weights = self.weights.astype(model_frame.dtype)
             if self.frame._psfs is not None:
-                self.frame._psfs = self.frame._psfs.astype(model_frame.dtype)
+                _psfs = self.frame._psfs.image.astype(model_frame.dtype)
+                self.frame._psfs = fft.Fourier(_psfs, axes=(1, 2))
 
         #  channels of model that are represented in this observation
         self._band_slice = slice(None)
@@ -244,64 +250,17 @@ class Observation():
             bmax = model_frame.channels.index(self.frame.channels[-1])
             self._band_slice = slice(bmin, bmax + 1)
 
-        self._diff_kernels_fft = None
+        self._diff_kernels = None
         if self.frame.psfs is not model_frame.psfs:
             assert self.frame.psfs is not None and model_frame.psfs is not None
-            # First we setup the parameters for the model -> observation FFTs
-            # Make the PSF stamp wider due to errors when matching PSFs
-            psf_shape = np.array(self.frame.psfs.shape)
-            psf_shape[1:] += self._padding
-            conv_shape = np.array(model_frame.shape) + psf_shape - 1
-            conv_shape[0] = model_frame.shape[0]
-
-            # Choose the optimal shape for FFTPack DFT
-            self._fftpack_shape = [fftpack.helper.next_fast_len(d) for d in conv_shape[1:]]
-
-            # autograd.numpy.fft does not currently work
-            # if the last dimension is odd
-            while self._fftpack_shape[-1] % 2 != 0:
-                _shape = self._fftpack_shape[-1] + 1
-                self._fftpack_shape[-1] = fftpack.helper.next_fast_len(_shape)
-
-
-            # Store the pre-fftpack optimization slices
-            self.slices = tuple(([slice(s) for s in conv_shape]))
-
-            # Now we setup the parameters for the psf -> kernel FFTs
-            shape = np.array(self.frame.psfs.shape) + np.array(model_frame.psfs.shape) - 1
-            shape[0] = np.array(self.frame.psfs.shape[0])
-
-            #Fast fft shapes for kernels
-            _fftpack_shape = [fftpack.helper.next_fast_len(d) for d in shape[1:]]
-
-            while _fftpack_shape[-1] % 2 != 0:
-                k_shape = np.array(_fftpack_shape) + 1
-                _fftpack_shape = [fftpack.helper.next_fast_len(k_s) for k_s in k_shape]
-
-            # fft of the target psf
-            target_fft = np.fft.rfftn(model_frame.psfs, _fftpack_shape, axes=(1, 2))
-
-            # fft of the observation's PSFs in each band
-            _psf_fft = np.fft.rfftn(self.frame.psfs, _fftpack_shape, axes=(1, 2))
-
-            # Diff kernel between observation and target psf in Fourrier
-            kernels = np.fft.ifftshift(np.fft.irfftn(_psf_fft / target_fft, _fftpack_shape, axes=(1, 2)), axes=(1, 2))
-
-            if kernels.shape[1] % 2 == 0 :
-                kernels = kernels[:, 1:, 1:]
-
-            kernels = _centered(kernels, psf_shape)
-
-            self._diff_kernels_fft = np.fft.rfftn(kernels, self._fftpack_shape, axes=(1, 2))
+            self._diff_kernels = fft.match_psfs(self.frame.psfs, model_frame.psfs)
 
         return self
 
     def _convolve(self, model):
         """Convolve the model in a single band
         """
-        model_fft = np.fft.rfftn(model, self._fftpack_shape, axes=(1, 2))
-        convolved = np.fft.irfftn(model_fft * self._diff_kernels_fft, self._fftpack_shape, axes=(1, 2))[self.slices]
-        return _centered(convolved, model.shape)
+        return fft.convolve(fft.Fourier(model, axes=(1, 2)), self._diff_kernels).image
 
     def render(self, model):
         """Convolve a model to the observation frame
@@ -317,7 +276,7 @@ class Observation():
             The convolved `model` in the observation frame
         """
         model_ = model[self._band_slice, :, :]
-        if self._diff_kernels_fft is not None:
+        if self._diff_kernels is not None:
             model_ = self._convolve(model_)
 
         return model_

--- a/scarlet/psf.py
+++ b/scarlet/psf.py
@@ -1,7 +1,10 @@
+from functools import partial
+
 import numpy as np
+from .interpolation import apply_2D_trapezoid_rule
 
 
-def moffat(coords, y0, x0, amplitude, alpha, beta=1.5):
+def moffat(y, x, y0, x0, amplitude, alpha, beta=1.5):
     """Moffat Function
 
     Symmetric 2D Moffat function:
@@ -10,33 +13,80 @@ def moffat(coords, y0, x0, amplitude, alpha, beta=1.5):
 
         A (1+\frac{(x-x0)^2+(y-y0)^2}{\alpha^2})^{-\beta}
     """
-    Y, X = coords
+    X, Y = np.meshgrid(x, y)
     return (amplitude*(1+((X-x0)**2+(Y-y0)**2)/alpha**2)**-beta)
 
 
-def gaussian(coords, y0, x0, amplitude, sigma):
+def gaussian(y, x, y0=0, x0=0, amplitude=None, sigma=1):
     """Circular Gaussian Function
+
+    Parameters
+    ----------
+    y: array
+        Coordinates to sample the circular gaussian in the y dimension.
+    x: array
+        Coordinates to sample the circular gaussian in the x dimension.
+    amplitude: float
+        Height of the gaussian. If `amplitude` is `None` then
+        `amplitude = 1/(np.pi**2*sigma**2)`
+        (so that the gaussian is normalized).
+    sigma: float
+        Standard deviation of the gaussian.
+
+    Returns
+    -------
+    result: array
+        A 2D circular gaussian sampled at the coordinates `(y_i, x_j)`
+        for all i in `y` and j in `x`.
     """
-    Y, X = coords
+    if amplitude is None:
+        amplitude = 1/(np.pi**2*sigma**2)
+    X, Y = np.meshgrid(x, y)
     return (amplitude*np.exp(-((X-x0)**2+(Y-y0)**2)/(2*sigma**2)))
 
 
-def double_gaussian(coords, y0, x0, A1, sigma1, A2, sigma2):
+def double_gaussian(y, x, y0=0, x0=0, A1=None, sigma1=1, A2=None, sigma2=1):
     """Sum of two Gaussian Functions
     """
-    return gaussian(coords, y0, x0, A1, sigma1) + gaussian(coords, y0, x0, A2, sigma2)
+    return gaussian(y, x, y0, x0, A1, sigma1) + gaussian(y, x, y0, x0, A2, sigma2)
 
 
-def generate_psf_image(func, shape, center=None, *args, **kwargs):
+def generate_psf_image(func, shape, subsamples=10, normalize=True, **kwargs):
     """Generate a PSF image based on a function and shape
+
+    This function uses a subdivided pixel scale to sample `func` at
+    higher frequencies and uses the trapezoid rule to estimate the integral
+    in each subsampled region. The subsampled pixel are then summed to
+    give the estimated integration values for each pixel at the scale requested
+    by `shape`.
+
+    Parameters
+    ----------
+    shape: tuple
+        Expected shape of the output image.
+    subsamples: int
+        Number of pixels to subdivide each output pixel for
+        a more accurate integration.
+    normalize: bool
+        Whether or not to normalize the PSF.
+    kwargs: keyword arguments
+        Keyword arguments to pass to `func`.
+
+    Returns
+    -------
+    result: array
+        Integrated image generated
     """
-    X = np.arange(shape[1])
-    Y = np.arange(shape[0])
-    X, Y = np.meshgrid(X, Y)
-    coords = np.stack([Y, X])
-    if center is None:
-        center = (shape[0]-1) // 2, (shape[1]-1) // 2
-    return func(coords, center[0], center[1], *args, **kwargs)
+    ry, rx = np.array(shape) // 2
+
+    y = np.linspace(-ry, ry, shape[0])
+    x = np.linspace(-rx, rx, shape[1])
+    f = partial(func, **kwargs)
+    #result = apply_2D_trapezoid_rule(y, x, partial(f, **kwargs), subsamples)
+    result = f(y, x, **kwargs)
+    if normalize:
+        result /= result.sum()
+    return result
 
 
 def fit_target_psf(psfs, func, init_values=None, extract_values=None):
@@ -74,9 +124,9 @@ def fit_target_psf(psfs, func, init_values=None, extract_values=None):
     """
     from scipy.optimize import curve_fit
 
-    X = np.arange(psfs.shape[2])
-    Y = np.arange(psfs.shape[1])
-    X, Y = np.meshgrid(X, Y)
+    x = np.arange(psfs.shape[2])
+    y = np.arange(psfs.shape[1])
+    X, Y = np.meshgrid(x, y)
     coords = np.stack([Y, X])
     y0, x0 = (psfs.shape[1]-1) // 2, (psfs.shape[2]-1) // 2
     init_params = [y0, x0]
@@ -95,7 +145,8 @@ def fit_target_psf(psfs, func, init_values=None, extract_values=None):
     def reshape_func(*args):
         """Flatten the function output to work with `scipy.curve_fit`
         """
-        return func(*args).reshape(-1)
+        _args = [y, x] + list(args[1:])
+        return func(*_args).reshape(-1)
 
     # Fit each PSF with the specified function and store the results
     for n, psf in enumerate(psfs):

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -390,7 +390,7 @@ class PointSource(Component):
         if self.symmetric:
             if self.frame.psfs is None:
                 shape = (41, 41)
-                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9)
+                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9, normalize=False)
                 psf /= psf.max()
                 self._centroid_weight = psf
             else:
@@ -483,7 +483,7 @@ class ExtendedSource(PointSource):
         if self.symmetric:
             if self.frame.psfs is None:
                 shape = (41, 41)
-                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9)
+                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9, normalize=False)
                 psf /= psf.max()
                 self._centroid_weight = psf
             else:
@@ -593,7 +593,7 @@ class MultiComponentSource(ComponentTree):
         if self.symmetric:
             if self.frame.psfs is None:
                 shape = (41, 41)
-                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9)
+                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9, normalize=False)
                 psf /= psf.max()
                 self._centroid_weight = psf
             else:

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -6,16 +6,14 @@ from numpy.testing import assert_almost_equal
 class TestPsf(object):
     def test_moffat(self):
         shape = 7, 7
-        X = np.arange(shape[1])
-        Y = np.arange(shape[0])
-        X, Y = np.meshgrid(X, Y)
-        coords = np.stack([Y, X])
+        x = np.arange(shape[1])
+        y = np.arange(shape[0])
         y0 = 3
         x0 = 5
         amplitude = 4.6
         alpha = 1.123
         beta = 1.491
-        result = scarlet.psf.moffat(coords, y0, x0, amplitude, alpha, beta)
+        result = scarlet.psf.moffat(y, x, y0, x0, amplitude, alpha, beta)
 
         truth = [[0.03206059739715075, 0.049750104330030576, 0.07898230258561093, 0.12363652428535422,
                   0.17582539510961576, 0.20197531771865862, 0.17582539510961576],
@@ -35,15 +33,13 @@ class TestPsf(object):
 
     def test_gaussian(self):
         shape = 7, 7
-        X = np.arange(shape[1])
-        Y = np.arange(shape[0])
-        X, Y = np.meshgrid(X, Y)
-        coords = np.stack([Y, X])
+        x = np.arange(shape[1])
+        y = np.arange(shape[0])
         y0 = 3
         x0 = 5
         amplitude = 4.6
         sigma = 1.872
-        result = scarlet.psf.gaussian(coords, y0, x0, amplitude, sigma)
+        result = scarlet.psf.gaussian(y, x, y0, x0, amplitude, sigma)
 
         truth = [[0.035972150170478605, 0.1299111667397572, 0.3526936664142025, 0.7198134054492321,
                   1.1043666731044601, 1.2737310805289048, 1.1043666731044601],
@@ -64,17 +60,15 @@ class TestPsf(object):
 
     def test_double_gaussian(self):
         shape = 7, 7
-        X = np.arange(shape[1])
-        Y = np.arange(shape[0])
-        X, Y = np.meshgrid(X, Y)
-        coords = np.stack([Y, X])
+        x = np.arange(shape[1])
+        y = np.arange(shape[0])
         y0 = 3
         x0 = 5
         A1 = 4.2
         sigma1 = .938
         A2 = 2.042
         sigma2 = 3.67
-        result = scarlet.psf.double_gaussian(coords, y0, x0, A1, sigma1, A2, sigma2)
+        result = scarlet.psf.double_gaussian(y, x, y0, x0, A1, sigma1, A2, sigma2)
 
         truth = [[0.5779677726051379, 0.8072428930726728, 1.0469367888293277, 1.2628823397211582,
                   1.4230484212789571, 1.4872678517124784, 1.4230484212789571],
@@ -95,7 +89,8 @@ class TestPsf(object):
 
     def test_generate_psf_image(self):
         # Gaussian
-        psf = scarlet.psf.generate_psf_image(scarlet.psf.gaussian, (5, 5), amplitude=1, sigma=.5)
+        psf = scarlet.psf.generate_psf_image(scarlet.psf.gaussian, (5, 5), normalize=False,
+                                             amplitude=1, sigma=.5)
         truth = [[0.0000001125, 0.0000453999, 0.0003354626, 0.0000453999, 0.0000001125],
                  [0.0000453999, 0.0183156389, 0.1353352832, 0.0183156389, 0.0000453999],
                  [0.0003354626, 0.1353352832, 1.0000000000, 0.1353352832, 0.0003354626],
@@ -103,7 +98,8 @@ class TestPsf(object):
                  [0.0000001125, 0.0000453999, 0.0003354626, 0.0000453999, 0.0000001125]]
         assert_almost_equal(psf, truth)
         # Moffat, with center
-        psf = scarlet.psf.generate_psf_image(scarlet.psf.moffat, (5, 5), (1, 2), 1, 2.3)
+        psf = scarlet.psf.generate_psf_image(scarlet.psf.moffat, (5, 5), normalize=False, y0=-1, x0=0,
+                                             amplitude=1, alpha=2.3)
         truth = [[0.3686043413, 0.6181476401, 0.7712719551, 0.6181476401, 0.3686043413],
                  [0.4296946407, 0.7712719551, 1.0000000000, 0.7712719551, 0.4296946407],
                  [0.3686043413, 0.6181476401, 0.7712719551, 0.6181476401, 0.3686043413],
@@ -113,15 +109,14 @@ class TestPsf(object):
 
     def test_fit_target_psf(self):
         shape = 21, 21
-        X = np.arange(shape[1])
-        Y = np.arange(shape[0])
-        X, Y = np.meshgrid(X, Y)
-        coords = np.stack([Y, X])
+        x = np.arange(shape[1])
+        y = np.arange(shape[0])
         y0 = 10
         x0 = 10
         amplitude = 4.6
         sigmas = [1.1, 0.91, 2.6, 1.02, 3.5]
-        psfs = np.array([scarlet.psf.gaussian(coords, y0, x0, amplitude, sigma) for sigma in sigmas])
+        psfs = np.array([scarlet.psf.gaussian(y, x, y0, x0, amplitude, sigma) for sigma in sigmas])
+        print(psfs.shape)
         target_psf, all_params, params = scarlet.psf.fit_target_psf(psfs, scarlet.psf.gaussian)
 
         assert_almost_equal(target_psf.sum(), 1)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -102,7 +102,8 @@ class TestUpdate(object):
         noise = np.random.rand(21, 21)*2  # noise background to eliminate
         signal = np.zeros(noise.shape)
         func = scarlet.psf.gaussian
-        signal[7:14, 7:14] = scarlet.psf.generate_psf_image(func, (21, 21), amplitude=10, sigma=3)[7:14, 7:14]
+        signal[7:14, 7:14] = scarlet.psf.generate_psf_image(func, (21, 21), normalize=False,
+                                                            amplitude=10, sigma=3)[7:14, 7:14]
         morph = signal + noise
         sed = np.arange(5)
         shape = (len(sed), morph.shape[0], morph.shape[1])


### PR DESCRIPTION
This ticket does two things:

* Implements a new `Fourier` class that stores an image and FFTs for any shape it has already calculated, making PSFs more useful and streamlining the psf matching code. It also fixes centering bug that can occur when performing operations in Fourier space
* Estimates the kernel to deconvolve the observations in order to make the initial morphology guess more accurate.