### PR TITLE
pep8 compliant code from black

### DIFF
--- a/scarlet/.pre-commit-config.yaml
+++ b/scarlet/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.7

--- a/scarlet/__init__.py
+++ b/scarlet/__init__.py
@@ -8,4 +8,4 @@ from .frame import *
 from .observation import *
 from .blend import *
 from . import operator
-from . import  measure
+from . import measure

--- a/scarlet/bbox.py
+++ b/scarlet/bbox.py
@@ -15,7 +15,8 @@ class Box:
     origin: tuple
         Minimum (z,y,x) value of the box (front low left corner).
     """
-    def __init__(self, shape, origin=(0,0,0)):
+
+    def __init__(self, shape, origin=(0, 0, 0)):
         # bbox always in 3D
         if len(shape) == 2:
             shape = (0, *shape)
@@ -69,7 +70,9 @@ class Box:
             top, bottom = bottom, top
         if right < left:
             right, left = left, right
-        return Box((back-front, top-bottom, right-left), origin=(front, bottom, left))
+        return Box(
+            (back - front, top - bottom, right - left), origin=(front, bottom, left)
+        )
 
     @staticmethod
     def from_data(X, min_value=0):
@@ -95,17 +98,17 @@ class Box:
                 bounds.append(nonzero[dim].min())
                 bounds.append(nonzero[dim].max() + 1)
             if len(X.shape) == 2:
-                bounds.insert(0,0)
-                bounds.insert(1,0)
+                bounds.insert(0, 0)
+                bounds.insert(1, 0)
         else:
-            bounds = [0,] * 6
+            bounds = [0] * 6
         return Box.from_bounds(*bounds)
 
     def contains(self, p):
         """Whether the box cotains a given coordinate `p`
         """
         if len(p) == 2:
-            p = (0,*p)
+            p = (0, *p)
 
         for d in range(len(self.shape)):
             if p[d] < self.origin[d] or p[d] > self.origin[d] + self.shape[d]:
@@ -125,15 +128,19 @@ class Box:
         If shape is 2D: `slice_y`, `slice_x`
         If shape is 3: `slice(None)`, `slice_y`, `slice_x`
         """
-        if hasattr(im_or_shape, 'shape'):
+        if hasattr(im_or_shape, "shape"):
             shape = im_or_shape.shape
         else:
             shape = im_or_shape
-        assert len(shape) in [2,3]
+        assert len(shape) in [2, 3]
 
         im_box = Box(shape)
         overlap = self & im_box
-        zslice, yslice, xslice = slice(overlap.front, overlap.back), slice(overlap.bottom, overlap.top), slice(overlap.left, overlap.right)
+        zslice, yslice, xslice = (
+            slice(overlap.front, overlap.back),
+            slice(overlap.bottom, overlap.top),
+            slice(overlap.left, overlap.right),
+        )
 
         if len(shape) == 2:
             return yslice, xslice
@@ -295,18 +302,20 @@ class Box:
         return Box.from_bounds(front, back, bottom, top, left, right)
 
     def __str__(self):
-        return "Box({0}..{1}, {2}..{3}, {4}..{5})".format(self.front, self.back, self.bottom, self.top, self.left, self.right)
+        return "Box({0}..{1}, {2}..{3}, {4}..{5})".format(
+            self.front, self.back, self.bottom, self.top, self.left, self.right
+        )
 
     def __repr__(self):
         result = "<Box shape={0}, origin={1}>"
         return result.format(self.shape, self.origin)
 
     def __iadd__(self, offset):
-        self.origin = tuple([a + o for a,o in zip(self.origin, offset)])
+        self.origin = tuple([a + o for a, o in zip(self.origin, offset)])
         return self
 
     def __isub__(self, offset):
-        self.origin = tuple([a - o for a,o in zip(self.origin, offset)])
+        self.origin = tuple([a - o for a, o in zip(self.origin, offset)])
         return self
 
     def __copy__(self):

--- a/scarlet/cache.py
+++ b/scarlet/cache.py
@@ -5,6 +5,7 @@ class Cache:
     that pushes content onto the cache, the `key` can be chosen at will.
 
     """
+
     _cache = {}
 
     @staticmethod

--- a/scarlet/constraint.py
+++ b/scarlet/constraint.py
@@ -7,6 +7,7 @@ from . import interpolation
 from . import operator
 from .cache import Cache
 
+
 class Constraint:
     """Constraint base class
 
@@ -25,6 +26,7 @@ class Constraint:
     For reference, every operator of the `proxmin` package yields a valid
     `Constraint`.
     """
+
     def __init__(self, f=None):
         """Constraint base class
 
@@ -66,6 +68,7 @@ class ConstraintChain:
     repeat: int
         How often the constrain chain is repeated to ensure feasibility
     """
+
     def __init__(self, *constraints, repeat=1):
         assert isinstance(repeat, int) and repeat >= 1
         self.constraints = constraints
@@ -81,12 +84,13 @@ class ConstraintChain:
 class PositivityConstraint(Constraint):
     """Allow only non-negative elements.
     """
+
     def __init__(self):
         super().__init__(proxmin.operators.prox_plus)
 
 
 class NormalizationConstraint(Constraint):
-    def __init__(self, type='sum'):
+    def __init__(self, type="sum"):
         """Normalize X to unity.
 
         Parameters
@@ -95,7 +99,7 @@ class NormalizationConstraint(Constraint):
             Whether the sum or the maximum is set to unity.
         """
         type = type.lower()
-        assert type in ['sum', 'max']
+        assert type in ["sum", "max"]
         self.type = type
 
     def __call__(self, X, step):
@@ -108,7 +112,7 @@ class NormalizationConstraint(Constraint):
 
 
 class L0Constraint(Constraint):
-    def __init__(self, thresh, type='relative'):
+    def __init__(self, thresh, type="relative"):
         """L0 norm (sparsity) penalty
 
         Parameters
@@ -123,7 +127,7 @@ class L0Constraint(Constraint):
 
 
 class L1Constraint(Constraint):
-    def __init__(self, thresh, type='relative'):
+    def __init__(self, thresh, type="relative"):
         """L1 norm (sparsity) penalty
 
         Parameters
@@ -148,9 +152,10 @@ class ThresholdConstraint(Constraint):
     The region that contains flux above the threshold is contained
     in `component.bboxes["thresh"]`.
     """
+
     def __call__(self, X, step):
         thresh, _bins = self.threshold(X)
-        return proxmin.operators.prox_hard_plus(X, step, thresh=thresh, type='absolute')
+        return proxmin.operators.prox_hard_plus(X, step, thresh=thresh, type="absolute")
 
     def threshold(self, morph):
         """Find the threshold value for a given morphology
@@ -159,7 +164,7 @@ class ThresholdConstraint(Constraint):
         _bins = 50
         # Decrease the bin size for sources with a small number of pixels
         if _morph.size < 500:
-            _bins = max(np.int(_morph.size/10), 1)
+            _bins = max(np.int(_morph.size / 10), 1)
             if _bins == 1:
                 return 0, _bins
         hist, bins = np.histogram(np.log10(_morph).reshape(-1), _bins)
@@ -167,7 +172,8 @@ class ThresholdConstraint(Constraint):
         # If all of the pixels are used there is no need to threshold
         if len(cutoff) == 0:
             return 0, _bins
-        return 10**bins[cutoff[-1]], _bins
+        return 10 ** bins[cutoff[-1]], _bins
+
 
 class MonotonicityConstraint(Constraint):
     """Make morphology monotonically decrease from the center
@@ -175,6 +181,7 @@ class MonotonicityConstraint(Constraint):
     See `~scarlet.operator.prox_monotonic`
     for a description of the other parameters.
     """
+
     def __init__(self, use_nearest=False, thresh=0):
         self.use_nearest = use_nearest
         self.thresh = thresh
@@ -191,7 +198,9 @@ class MonotonicityConstraint(Constraint):
         try:
             prox = Cache.check(prox_name, key)
         except KeyError:
-            prox = operator.prox_strict_monotonic(shape, use_nearest=self.use_nearest,thresh=self.thresh, center=center)
+            prox = operator.prox_strict_monotonic(
+                shape, use_nearest=self.use_nearest, thresh=self.thresh, center=center
+            )
 
             Cache.set(prox_name, key, prox)
 
@@ -205,6 +214,7 @@ class SymmetryConstraint(Constraint):
     See `~scarlet.operator.prox_uncentered_symmetry`
     for a description of the parameters.
     """
+
     def __init__(self, strength=1):
         self.strength = strength
 
@@ -215,6 +225,7 @@ class SymmetryConstraint(Constraint):
 class CenterOnConstraint(Constraint):
     """Sets the center pixel to a tiny non-zero value
     """
+
     def __init__(self, tiny=1e-6):
         self.tiny = tiny
 
@@ -224,9 +235,11 @@ class CenterOnConstraint(Constraint):
         morph[center] = max(morph[center], self.tiny)
         return morph
 
+
 class AllOnConstraint(Constraint):
     """Add to all elements a tiny non-zero value
     """
+
     def __init__(self, tiny=1e-6):
         self.tiny = tiny
 

--- a/scarlet/display.py
+++ b/scarlet/display.py
@@ -3,6 +3,7 @@ from astropy.visualization.lupton_rgb import LinearMapping, AsinhMapping
 import matplotlib.pyplot as plt
 from .component import ComponentTree
 
+
 def channels_to_rgb(channels):
     """Get the linear mapping of multiple channels to RGB channels
 
@@ -20,7 +21,9 @@ def channels_to_rgb(channels):
     -------
     array (3, channels) to map onto RGB
     """
-    assert channels in range(0,7), "No mapping has been implemented for more than {} channels".format(channels)
+    assert channels in range(
+        0, 7
+    ), "No mapping has been implemented for more than {} channels".format(channels)
 
     channel_map = np.zeros((3, channels))
     if channels == 1:
@@ -171,9 +174,18 @@ def img_to_rgb(img, channel_map=None, fill_value=0, norm=None):
     rgb = norm.make_rgb_image(*RGB)
     return rgb
 
-def show_scene(sources, observation=None, norm=None, channel_map=None,
-show_observed=False, show_rendered=False, show_residual=False, label_sources=True,
-figsize=None):
+
+def show_scene(
+    sources,
+    observation=None,
+    norm=None,
+    channel_map=None,
+    show_observed=False,
+    show_rendered=False,
+    show_residual=False,
+    label_sources=True,
+    figsize=None,
+):
     """Plot all sources to recreate the scence.
 
     The functions provides a fast way of evaluating the quality of the entire model,
@@ -201,13 +213,15 @@ figsize=None):
     matplotlib figure
     """
     if show_observed or show_rendered or show_residual:
-        assert observation is not None, "Provide matched observation to show observed frame"
+        assert (
+            observation is not None
+        ), "Provide matched observation to show observed frame"
 
     panels = 1 + sum((show_observed, show_rendered, show_residual))
     if figsize is None:
-        figsize = (3*panels, 3*len(list(sources)))
+        figsize = (3 * panels, 3 * len(list(sources)))
     fig, ax = plt.subplots(1, panels, figsize=figsize)
-    if not hasattr(ax, '__iter__'):
+    if not hasattr(ax, "__iter__"):
         ax = (ax,)
 
     panel = 0
@@ -226,7 +240,9 @@ figsize=None):
 
     if show_observed:
         panel += 1
-        ax[panel].imshow(img_to_rgb(observation.images, norm=norm, channel_map=channel_map))
+        ax[panel].imshow(
+            img_to_rgb(observation.images, norm=norm, channel_map=channel_map)
+        )
         ax[panel].set_title("Observation")
 
     if show_residual:
@@ -238,19 +254,30 @@ figsize=None):
 
     if label_sources:
         for k, src in enumerate(sources):
-            if hasattr(src, 'center'):
+            if hasattr(src, "center"):
                 center = np.array(src.center)
-                center_ = center - np.array(src.frame.origin[1:]) # observed coordinates
-            ax[0].text(*center[::-1], k, color='w')
+                center_ = center - np.array(
+                    src.frame.origin[1:]
+                )  # observed coordinates
+            ax[0].text(*center[::-1], k, color="w")
             for panel in range(1, panels):
-                ax[panel].text(*center_[::-1], k, color='w')
+                ax[panel].text(*center_[::-1], k, color="w")
 
     fig.tight_layout()
-    plt.close();
+    plt.close()
     return fig
 
-def show_sources(sources, observation=None, norm=None, channel_map=None,
-show_observed=False, show_rendered=False, show_sed=True, figsize=None):
+
+def show_sources(
+    sources,
+    observation=None,
+    norm=None,
+    channel_map=None,
+    show_observed=False,
+    show_rendered=False,
+    show_sed=True,
+    figsize=None,
+):
     """Plot each source individually.
 
     The functions provides an more detailed inspection of every source in the list.
@@ -276,15 +303,17 @@ show_observed=False, show_rendered=False, show_sed=True, figsize=None):
     matplotlib figure
     """
     if show_observed or show_rendered:
-        assert observation is not None, "Provide matched observation to show observed frame"
+        assert (
+            observation is not None
+        ), "Provide matched observation to show observed frame"
 
     panels = 1 + sum((show_observed, show_rendered, show_sed))
     if figsize is None:
-        figsize = (3*panels, 3*len(list(sources)))
+        figsize = (3 * panels, 3 * len(list(sources)))
     fig, ax = plt.subplots(len(list(sources)), panels, figsize=figsize)
-    for k,src in enumerate(sources):
+    for k, src in enumerate(sources):
 
-        if hasattr(src, 'center'):
+        if hasattr(src, "center"):
             center = np.array(src.center)
             # center in src bbox coordinates
             if src.bbox is not None:
@@ -304,11 +333,11 @@ show_observed=False, show_rendered=False, show_sed=True, figsize=None):
             seds = []
             for component in src:
                 model_ = component.get_model()
-                seds.append(model_.sum(axis=(1,2)))
+                seds.append(model_.sum(axis=(1, 2)))
                 model += model_
         else:
             model = src.get_model()
-            seds = [model.sum(axis=(1,2))]
+            seds = [model.sum(axis=(1, 2))]
         src.set_frame(frame_)
         ax[k][panel].imshow(img_to_rgb(model, norm=norm, channel_map=channel_map))
         ax[k][panel].set_title("Model Source {}".format(k))
@@ -328,7 +357,9 @@ show_observed=False, show_rendered=False, show_sed=True, figsize=None):
 
         if show_observed:
             panel += 1
-            ax[k][panel].imshow(img_to_rgb(observation.images, norm=norm, channel_map=channel_map))
+            ax[k][panel].imshow(
+                img_to_rgb(observation.images, norm=norm, channel_map=channel_map)
+            )
             ax[k][panel].set_xlim(src.bbox.left, src.bbox.right)
             ax[k][panel].set_ylim(src.bbox.bottom, src.bbox.top)
             ax[k][panel].set_title("Observation".format(k))
@@ -340,12 +371,12 @@ show_observed=False, show_rendered=False, show_sed=True, figsize=None):
             for sed in seds:
                 ax[k][panel].plot(sed)
             ax[k][panel].set_xticks(range(len(sed)))
-            if hasattr(src.frame, 'channels') and src.frame.channels is not None:
+            if hasattr(src.frame, "channels") and src.frame.channels is not None:
                 ax[k][panel].set_xticklabels(src.frame.channels)
             ax[k][panel].set_title("SED")
             ax[k][panel].set_xlabel("Channel")
             ax[k][panel].set_ylabel("Intensity")
 
     fig.tight_layout()
-    plt.close();
+    plt.close()
     return fig

--- a/scarlet/fft.py
+++ b/scarlet/fft.py
@@ -25,10 +25,12 @@ def _centered(arr, newshape):
     currshape = np.array(arr.shape)
 
     if not np.all(newshape <= currshape):
-        msg = "arr must be larger than newshape in both dimensions, received {0}, and {1}"
+        msg = (
+            "arr must be larger than newshape in both dimensions, received {0}, and {1}"
+        )
         raise ValueError(msg.format(arr.shape, newshape))
 
-    startind = (currshape - newshape+1) // 2
+    startind = (currshape - newshape + 1) // 2
     endind = startind + newshape
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
 
@@ -47,7 +49,7 @@ def _pad(arr, newshape, axes=None):
         newshape = np.asarray(newshape)
         currshape = np.array(arr.shape)
         dS = newshape - currshape
-        startind = (dS+1) // 2
+        startind = (dS + 1) // 2
         endind = dS - startind
         pad_width = list(zip(startind, endind))
     else:
@@ -59,13 +61,13 @@ def _pad(arr, newshape, axes=None):
             axes = [axes]
         for a, axis in enumerate(axes):
             dS = newshape[a] - arr.shape[axis]
-            startind = (dS+1) // 2
+            startind = (dS + 1) // 2
             endind = dS - startind
             pad_width[axis] = (startind, endind)
     return np.pad(arr, pad_width, mode="constant")
 
 
-def _get_fft_shape(img1, img2, padding=3, axes=None, max = False):
+def _get_fft_shape(img1, img2, padding=3, axes=None, max=False):
     """Return the fast fft shapes for each spatial axis
 
     Calculate the fast fft shape for each dimension in
@@ -75,7 +77,9 @@ def _get_fft_shape(img1, img2, padding=3, axes=None, max = False):
     shape2 = np.asarray(img2.shape)
     # Make sure the shapes are the same size
     if len(shape1) != len(shape2):
-        msg = "img1 and img2 must have the same number of dimensions, but got {0} and {1}"
+        msg = (
+            "img1 and img2 must have the same number of dimensions, but got {0} and {1}"
+        )
         raise ValueError(msg.format(len(shape1), len(shape2)))
     # Set the combined shape based on the total dimensions
     if axes is None:
@@ -92,7 +96,7 @@ def _get_fft_shape(img1, img2, padding=3, axes=None, max = False):
         for n, ax in enumerate(axes):
             shape[n] = shape1[ax] + shape2[ax]
             if max == True:
-                shape[n] = np.max([shape1[ax],shape2[ax]])
+                shape[n] = np.max([shape1[ax], shape2[ax]])
 
     shape += padding
     # Use the next fastest shape in each dimension
@@ -116,6 +120,7 @@ class Fourier(object):
     padding, so the FFT for each different shape is stored
     in a dictionary.
     """
+
     def __init__(self, image, image_fft=None):
         """Initialize the object
 
@@ -196,7 +201,7 @@ class Fourier(object):
         try:
             iter(axes)
         except TypeError:
-            axes = (axes, )
+            axes = (axes,)
         all_axes = range(len(self.image.shape))
         fft_key = (tuple(fft_shape), tuple(axes), tuple(all_axes))
 
@@ -219,16 +224,33 @@ class Fourier(object):
             index = tuple([index])
 
         # Axes that are removed from the shape of the new object
-        removed = np.array([n for n, idx in enumerate(index)
-                            if not isinstance(idx, slice) and idx is not None])
+        removed = np.array(
+            [
+                n
+                for n, idx in enumerate(index)
+                if not isinstance(idx, slice) and idx is not None
+            ]
+        )
 
         # Create views into the fft transformed values, appropriately adjusting
         # the shapes for the new axes
 
         fft_kernels = {
-            (tuple([s for idx, s in enumerate(key[0]) if key[1][idx] not in removed]),
-            tuple([a for ida, a in enumerate(key[1]) if key[1][ida] not in removed]),
-            tuple([aa for idaa, aa in enumerate(key[2]) if key[2][idaa] not in removed])): kernel[index]
+            (
+                tuple(
+                    [s for idx, s in enumerate(key[0]) if key[1][idx] not in removed]
+                ),
+                tuple(
+                    [a for ida, a in enumerate(key[1]) if key[1][ida] not in removed]
+                ),
+                tuple(
+                    [
+                        aa
+                        for idaa, aa in enumerate(key[2])
+                        if key[2][idaa] not in removed
+                    ]
+                ),
+            ): kernel[index]
             for key, kernel in self._fft.items()
         }
         return Fourier(self.image[index], fft_kernels)
@@ -247,12 +269,12 @@ def _kspace_operation(image1, image2, padding, op, shape, axes):
         raise Exception(msg.format(len(image1.shape), len(image2.shape)))
     fft_shape = _get_fft_shape(image1.image, image2.image, padding, axes)
     convolved_fft = op(image1.fft(fft_shape, axes), image2.fft(fft_shape, axes))
-    #why is shape not image1.shape? images are never padded
+    # why is shape not image1.shape? images are never padded
     convolved = Fourier.from_fft(convolved_fft, fft_shape, shape, axes)
     return convolved
 
 
-def match_psfs(psf1, psf2, padding=3, axes = (-2,-1)):
+def match_psfs(psf1, psf2, padding=3, axes=(-2, -1)):
     """Calculate the difference kernel between two psfs
 
     Parameters
@@ -271,10 +293,10 @@ def match_psfs(psf1, psf2, padding=3, axes = (-2,-1)):
         shape = psf2.shape
     else:
         shape = psf1.shape
-    return _kspace_operation(psf1, psf2, padding, operator.truediv, shape, axes = axes)
+    return _kspace_operation(psf1, psf2, padding, operator.truediv, shape, axes=axes)
 
 
-def convolve(image1, image2, padding=3, axes= (-2,-1)):
+def convolve(image1, image2, padding=3, axes=(-2, -1)):
     """Convolve two images
 
     Parameters
@@ -287,4 +309,6 @@ def convolve(image1, image2, padding=3, axes= (-2,-1)):
         Additional padding to use when generating the FFT
         to supress artifacts.
     """
-    return _kspace_operation(image1, image2, padding, operator.mul, image1.shape, axes = axes)
+    return _kspace_operation(
+        image1, image2, padding, operator.mul, image1.shape, axes=axes
+    )

--- a/scarlet/frame.py
+++ b/scarlet/frame.py
@@ -3,7 +3,9 @@ from .psf import PSF
 from .bbox import Box
 
 import logging
+
 logger = logging.getLogger("scarlet.frame")
+
 
 class Frame(Box):
     """Spatial and spectral characteristics of the data
@@ -21,7 +23,10 @@ class Frame(Box):
     dtype: `numpy.dtype`
         Dtype to represent the data.
     """
-    def __init__(self, shape_or_box, wcs=None, psfs=None, channels=None, dtype=np.float32):
+
+    def __init__(
+        self, shape_or_box, wcs=None, psfs=None, channels=None, dtype=np.float32
+    ):
 
         if isinstance(shape_or_box, Box):
             self = shape_or_box
@@ -31,7 +36,7 @@ class Frame(Box):
         self.wcs = wcs
 
         if psfs is None:
-            logger.warning('No PSF specified. Possible, but dangerous!')
+            logger.warning("No PSF specified. Possible, but dangerous!")
             self._psfs = None
         else:
             if isinstance(psfs, PSF):
@@ -42,7 +47,6 @@ class Frame(Box):
         assert channels is None or len(channels) == self.shape[0]
         self.channels = channels
         self.dtype = dtype
-
 
     @property
     def psf(self):
@@ -60,7 +64,9 @@ class Frame(Box):
             elif self.wcs.naxis == 2:
                 coord = self.wcs.wcs_world2pix(*sky_coord, 0)
             else:
-                raise ValueError("Invalid number of wcs dimensions: {0}".format(self.wcs.naxis))
+                raise ValueError(
+                    "Invalid number of wcs dimensions: {0}".format(self.wcs.naxis)
+                )
             return tuple(int(c.item()) for c in coord)
 
         return tuple(int(coord) for coord in sky_coord)
@@ -77,7 +83,9 @@ class Frame(Box):
             elif self.wcs.naxis == 2:
                 coord = self.wcs.wcs_pix2world(*pixel, 0)
             else:
-                raise ValueError("Invalid number of wcs dimensions: {0}".format(self.wcs.naxis))
+                raise ValueError(
+                    "Invalid number of wcs dimensions: {0}".format(self.wcs.naxis)
+                )
             return tuple(c.item() for c in coord)
 
         return tuple(pixel)

--- a/scarlet/interpolation.py
+++ b/scarlet/interpolation.py
@@ -125,6 +125,7 @@ def fft_convolve(*images):
         The convolution in pixel space of `img` with `kernel`.
     """
     from autograd.numpy.numpy_boxes import ArrayBox
+
     Images = [np.fft.fft2(np.fft.ifftshift(img)) for img in images]
     if np.any([isinstance(img, ArrayBox) for img in images]):
         Convolved = Images[0]
@@ -206,9 +207,9 @@ def cubic_spline(dx, a=1, b=0):
 
     window = np.arange(-1, 3) + np.floor(dx)
     x = np.abs(dx - window)
-    result = np.piecewise(x,
-                          [x <= 1, (x > 1) & (x < 2)],
-                          [lambda x: inner(x), lambda x: outer(x)])
+    result = np.piecewise(
+        x, [x <= 1, (x > 1) & (x < 2)], [lambda x: inner(x), lambda x: outer(x)]
+    )
 
     return result, np.array(window).astype(int)
 
@@ -218,7 +219,7 @@ def catmull_rom(dx):
 
     See `cubic_spline` for details.
     """
-    return cubic_spline(dx, a=.5, b=0)
+    return cubic_spline(dx, a=0.5, b=0)
 
 
 def mitchel_netravali(dx):
@@ -264,9 +265,11 @@ def quintic_spline(dx, dtype=np.float64):
 
     window = np.arange(-3, 4)
     x = np.abs(dx - window)
-    result = np.piecewise(x,
-                          [x <= 1, (x > 1) & (x <= 2), (x > 2) & (x <= 3)],
-                          [lambda x: inner(x), lambda x: middle(x), lambda x: outer(x)])
+    result = np.piecewise(
+        x,
+        [x <= 1, (x > 1) & (x <= 2), (x > 2) & (x <= 3)],
+        [lambda x: inner(x), lambda x: middle(x), lambda x: outer(x)],
+    )
     return result, window
 
 
@@ -299,8 +302,8 @@ def get_separable_kernel(dy, dx, kernel=lanczos, **kwargs):
     return kyx, y_window, x_window
 
 
-def mk_shifter(shape, real = False):
-    ''' Performs shifts in the Fourier domain on Fourier objects
+def mk_shifter(shape, real=False):
+    """ Performs shifts in the Fourier domain on Fourier objects
 
     Parameters:
     -----------
@@ -313,10 +316,10 @@ def mk_shifter(shape, real = False):
     --------
     result: Fourier
         A Fourier object with shifted arrays
-    '''
+    """
 
-    #Name of the chached shifts.
-    name = 'mk_shifter'
+    # Name of the chached shifts.
+    name = "mk_shifter"
     key = shape[0], shape[1]
 
     try:
@@ -339,8 +342,9 @@ def mk_shifter(shape, real = False):
 
     return shifters
 
-def sinc_interp(images, coord_hr, coord_lr, angle = None, padding = 3):
-    '''
+
+def sinc_interp(images, coord_hr, coord_lr, angle=None, padding=3):
+    """
     Parameters
     ----------
     image: array
@@ -356,7 +360,7 @@ def sinc_interp(images, coord_hr, coord_lr, angle = None, padding = 3):
     Returns
     -------
         result:  interpolated  samples at positions coord_hr
-    '''
+    """
     y_hr, x_hr = coord_hr
     y_lr, x_lr = coord_lr
     hy = np.abs(y_lr[1] - y_lr[0])
@@ -366,43 +370,53 @@ def sinc_interp(images, coord_hr, coord_lr, angle = None, padding = 3):
     assert hx != 0
 
     if angle is None:
-        result = [np.dot(np.dot(np.sinc((y_lr[np.newaxis, :]-y_hr[:, np.newaxis]) / hy),image.T),
-                                        np.sinc((x_lr[:, np.newaxis]-x_hr[np.newaxis,:])/ hx) ) for image in images]
+        result = [
+            np.dot(
+                np.dot(
+                    np.sinc((y_lr[np.newaxis, :] - y_hr[:, np.newaxis]) / hy), image.T
+                ),
+                np.sinc((x_lr[:, np.newaxis] - x_hr[np.newaxis, :]) / hx),
+            )
+            for image in images
+        ]
         return np.array(result)
 
     cos = angle[0]
     sin = angle[1]
 
-    fft_shape = fft._get_fft_shape(images, images, padding=padding, axes = [1, 2])
+    fft_shape = fft._get_fft_shape(images, images, padding=padding, axes=[1, 2])
 
     X = fft.Fourier(images)
-    #Fourier transform
+    # Fourier transform
     X_fft = X.fft(fft_shape, (1, 2))
 
-    #Shift elementary kernel
+    # Shift elementary kernel
     shifter_y, shifter_x = mk_shifter(fft_shape)
-    #Shifts values
-    shift_y = shifter_y[np.newaxis, :] ** (-y_hr[:, np.newaxis] * cos/hy)
-    shift_x = shifter_x[np.newaxis, :] ** (-y_hr[:, np.newaxis] * sin/hx)
-    #Apply shifts
+    # Shifts values
+    shift_y = shifter_y[np.newaxis, :] ** (-y_hr[:, np.newaxis] * cos / hy)
+    shift_x = shifter_x[np.newaxis, :] ** (-y_hr[:, np.newaxis] * sin / hx)
+    # Apply shifts
     result_fft = X_fft[:, np.newaxis, :, :] * shift_y[np.newaxis, :, :, np.newaxis]
     result_fft = result_fft * shift_x[np.newaxis, :, np.newaxis, :]
 
-    #Shape of the expected array
-    result_shape = np.array([result_fft.shape[0], result_fft.shape[1], X.image.shape[1], X.image.shape[2]])
-    #Shifts applied in one direction
+    # Shape of the expected array
+    result_shape = np.array(
+        [result_fft.shape[0], result_fft.shape[1], X.image.shape[1], X.image.shape[2]]
+    )
+    # Shifts applied in one direction
     result_shift = fft.Fourier.from_fft(result_fft, fft_shape, result_shape, [2, 3])
-    #sinc kernels
-    shy = np.sinc((y_lr[np.newaxis, :] + x_hr[:, np.newaxis] * sin)/hy)
-    shx = np.sinc((x_lr[np.newaxis, :] - x_hr[:, np.newaxis] * cos)/hx)
+    # sinc kernels
+    shy = np.sinc((y_lr[np.newaxis, :] + x_hr[:, np.newaxis] * sin) / hy)
+    shx = np.sinc((x_lr[np.newaxis, :] - x_hr[:, np.newaxis] * cos) / hx)
 
-    #Sinc kernels in both direction
-    result_y = (result_shift.image[:, :, np.newaxis,:, :] *
-                shy[np.newaxis, np.newaxis, :, :, np.newaxis]).sum(axis = -2)
-    result = (result_y * shx[np.newaxis,np.newaxis,:, :]).sum(axis = -1)
+    # Sinc kernels in both direction
+    result_y = (
+        result_shift.image[:, :, np.newaxis, :, :]
+        * shy[np.newaxis, np.newaxis, :, :, np.newaxis]
+    ).sum(axis=-2)
+    result = (result_y * shx[np.newaxis, np.newaxis, :, :]).sum(axis=-1)
 
     return result
-
 
 
 def fft_resample(img, dy, dx, kernel=lanczos, **kwargs):
@@ -488,7 +502,7 @@ def get_common_padding(img1, img2, padding=None):
 
 
 def sinc2D(y, x):
-    '''
+    """
     2-D sinc function based on the product of 2 1-D sincs
 
     Parameters
@@ -499,7 +513,7 @@ def sinc2D(y, x):
     -------
     result: array
         2-D sinc evaluated in x and y
-    '''
+    """
     return np.dot(np.sinc(y), np.sinc(x))
 
 
@@ -517,12 +531,12 @@ def subsample_function(y, x, f, dNy, dNx=None, dy=None, dx=None):
         dNx = dNy
     assert dNy % 2 == 0, "dNy must be even, received {0}".format(dNy)
     assert dNx % 2 == 0, "dNx must be even, received {0}".format(dNx)
-    assert np.all(np.isclose(x[1:]-x[:-1], x[1] - x[0])), "x must have equal spacing"
-    assert np.all(np.isclose(y[1:]-y[:-1], y[1] - y[0])), "y must have equal spacing"
+    assert np.all(np.isclose(x[1:] - x[:-1], x[1] - x[0])), "x must have equal spacing"
+    assert np.all(np.isclose(y[1:] - y[:-1], y[1] - y[0])), "y must have equal spacing"
 
     # Create the subsampled interval and use it to sample `f`
-    _x = np.linspace(x[0]-dx/2, x[-1]+dx/2, len(x)*dNx+1)
-    _y = np.linspace(y[0]-dy/2, y[-1]+dy/2, len(y)*dNy+1)
+    _x = np.linspace(x[0] - dx / 2, x[-1] + dx / 2, len(x) * dNx + 1)
+    _y = np.linspace(y[0] - dy / 2, y[-1] + dy / 2, len(y) * dNy + 1)
     return f(_y, _x), _y, _x
 
 
@@ -548,5 +562,7 @@ def apply_2D_trapezoid_rule(y, x, f, dNy, dNx=None, dy=None, dx=None):
     # give it the same shape as the original `(y,x)`
     _dNy = len(_y) // dNy
     _dNx = len(_x) // dNx
-    volumes = np.array(np.split(np.array(np.split(volumes, _dNx, axis=1)), _dNy, axis=1)).sum(axis=(2, 3))
+    volumes = np.array(
+        np.split(np.array(np.split(volumes, _dNx, axis=1)), _dNy, axis=1)
+    ).sum(axis=(2, 3))
     return volumes

--- a/scarlet/measure.py
+++ b/scarlet/measure.py
@@ -1,12 +1,14 @@
 import numpy as np
 from .component import *
 
+
 def get_model(component):
     frame_ = component.frame
     component.set_frame(component.bbox)
     model = component.get_model()
     component.set_frame(frame_)
     return model
+
 
 def max_pixel(component):
     """Determine pixel with maximum value
@@ -17,7 +19,10 @@ def max_pixel(component):
         Component to analyze
     """
     model = get_model(component)
-    return tuple(np.unravel_index(np.argmax(model_), model.shape) + component.bbox.origin)
+    return tuple(
+        np.unravel_index(np.argmax(model_), model.shape) + component.bbox.origin
+    )
+
 
 def flux(component):
     """Determine flux in every channel
@@ -28,7 +33,8 @@ def flux(component):
         Component to analyze
     """
     model = get_model(component)
-    return model.sum(axis=(1,2))
+    return model.sum(axis=(1, 2))
+
 
 def centroid(component):
     """Determine centroid of model
@@ -40,5 +46,5 @@ def centroid(component):
     """
     model = get_model(component)
     indices = np.indices(model.shape)
-    centroid = np.array([np.sum(ind*model) for ind in indices]) / model.sum()
+    centroid = np.array([np.sum(ind * model) for ind in indices]) / model.sum()
     return centroid + component.bbox.origin

--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -8,10 +8,12 @@ from . import fft
 from . import interpolation
 from .cache import Cache
 
+
 def _prox_strict_monotonic(X, step, ref_idx, dist_idx, thresh=0):
     """Force an intensity profile to be monotonic based on nearest neighbor
     """
     from . import operators_pybind11
+
     operators_pybind11.prox_monotonic(X.reshape(-1), ref_idx, dist_idx, thresh)
     return X
 
@@ -20,7 +22,10 @@ def _prox_weighted_monotonic(X, step, weights, didx, offsets, thresh=0):
     """Force an intensity profile to be monotonic based on weighting neighbors
     """
     from . import operators_pybind11
-    operators_pybind11.prox_weighted_monotonic(X.reshape(-1), weights, offsets, didx, thresh)
+
+    operators_pybind11.prox_weighted_monotonic(
+        X.reshape(-1), weights, offsets, didx, thresh
+    )
     return X
 
 
@@ -49,8 +54,8 @@ def sort_by_radius(shape, center=None):
     """
     # Get the center pixels
     if center is None:
-        cx = (shape[1]-1) >> 1
-        cy = (shape[0]-1) >> 1
+        cx = (shape[1] - 1) >> 1
+        cy = (shape[0] - 1) >> 1
     else:
         cy, cx = int(center[0]), int(center[1])
     # Calculate the distance between each pixel and the peak
@@ -59,7 +64,7 @@ def sort_by_radius(shape, center=None):
     X, Y = np.meshgrid(x, y)
     X = X - cx
     Y = Y - cy
-    distance = np.sqrt(X**2+Y**2)
+    distance = np.sqrt(X ** 2 + Y ** 2)
     # Get the indices of the pixels sorted by distance from the peak
     didx = np.argsort(distance.flatten())
     return didx
@@ -91,21 +96,33 @@ def prox_strict_monotonic(shape, use_nearest=False, thresh=0, center=None):
 
     if use_nearest:
         from scipy import sparse
+
         if thresh != 0:
             # thresh and nearest neighbors are not compatible, since this thresholds the
             # central pixel and eventually sets the entire array to zero
-            raise ValueError("Thresholding does not work with nearest neighbor monotonicity")
+            raise ValueError(
+                "Thresholding does not work with nearest neighbor monotonicity"
+            )
         monotonicOp = getRadialMonotonicOp(shape, useNearest=True)
         x_idx, ref_idx = sparse.find(monotonicOp.L == 1)[:2]
         ref_idx = ref_idx[np.argsort(x_idx)]
-        result = partial(_prox_strict_monotonic, ref_idx=ref_idx.tolist(),
-                         dist_idx=didx.tolist(), thresh=thresh)
+        result = partial(
+            _prox_strict_monotonic,
+            ref_idx=ref_idx.tolist(),
+            dist_idx=didx.tolist(),
+            thresh=thresh,
+        )
     else:
         coords = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
-        offsets = np.array([width*y+x for y, x in coords])
+        offsets = np.array([width * y + x for y, x in coords])
         weights = getRadialMonotonicWeights(shape, useNearest=False, center=center)
-        result = partial(_prox_weighted_monotonic, weights=weights,
-                         didx=didx[1:], offsets=offsets, thresh=thresh)
+        result = partial(
+            _prox_weighted_monotonic,
+            weights=weights,
+            didx=didx[1:],
+            offsets=offsets,
+            thresh=thresh,
+        )
     return result
 
 
@@ -164,8 +181,8 @@ def uncentered_operator(X, func, center=None, fill=None, **kwargs):
     if py == cy and px == cx:
         return func(X, **kwargs)
 
-    dy = int(2*(py-cy))
-    dx = int(2*(px-cx))
+    dy = int(2 * (py - cy))
+    dx = int(2 * (px - cx))
     if not X.shape[0] % 2:
         dy += 1
     if not X.shape[1] % 2:
@@ -207,7 +224,7 @@ def prox_soft_symmetry(X, step, strength=1):
     1  being completely symmetric, the user can customize
     the level of symmetry required for a component
     """
-    pads = [[0,0],[0,0]]
+    pads = [[0, 0], [0, 0]]
     slices = [slice(None), slice(None)]
     if X.shape[0] % 2 == 0:
         pads[0][1] = 1
@@ -216,10 +233,11 @@ def prox_soft_symmetry(X, step, strength=1):
         pads[1][1] = 1
         slices[1] = slice(0, X.shape[1])
 
-    X = np.pad(X, pads, mode='constant', constant_values=0)
-    Xs =  np.fliplr(np.flipud(X))
-    X = 0.5 * strength * (X+Xs) + (1-strength) * X
+    X = np.pad(X, pads, mode="constant", constant_values=0)
+    Xs = np.fliplr(np.flipud(X))
+    X = 0.5 * strength * (X + Xs) + (1 - strength) * X
     return X[tuple(slices)]
+
 
 def prox_kspace_symmetry(X, step, shift=None, padding=10):
     """Symmetry in Fourier Space
@@ -236,30 +254,32 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
     dy, dx = shift
 
     X = fft.Fourier(X)
-    X_fft = X.fft(fft_shape, (0,1))
+    X_fft = X.fft(fft_shape, (0, 1))
 
     zeroMask = X.image <= 0
 
-    #Compute shift operator
+    # Compute shift operator
     shifter_y, shifter_x = interpolation.mk_shifter(fft_shape)
-    #Apply shift in Fourier
+    # Apply shift in Fourier
     result_fft = X_fft * shifter_y[:, np.newaxis] ** (-dy)
     result_fft *= shifter_x[np.newaxis, :] ** (-dx)
 
-    #symmetrize
+    # symmetrize
     result_fft = result_fft.real
 
-    #Unshift
+    # Unshift
     result_fft = result_fft * shifter_y[:, np.newaxis] ** dy
     result_fft = result_fft * shifter_x[np.newaxis, :] ** dx
 
-    result = fft.Fourier.from_fft(result_fft, fft_shape, X.image.shape, [0,1])
+    result = fft.Fourier.from_fft(result_fft, fft_shape, X.image.shape, [0, 1])
 
     result.image[zeroMask] = 0
     return np.real(result.image)
 
 
-def prox_uncentered_symmetry(X, step, center=None, algorithm="kspace", fill=None, shift=None, strength=.5):
+def prox_uncentered_symmetry(
+    X, step, center=None, algorithm="kspace", fill=None, shift=None, strength=0.5
+):
     """Symmetry with off-center peak
 
     Symmetrize X for all pixels with a symmetric partner.
@@ -309,13 +329,17 @@ def prox_uncentered_symmetry(X, step, center=None, algorithm="kspace", fill=None
         algorithm = "soft"
         strength = 1
     if algorithm == "kspace":
-        return uncentered_operator(X, prox_kspace_symmetry, center, shift=shift, step=step, fill=fill)
+        return uncentered_operator(
+            X, prox_kspace_symmetry, center, shift=shift, step=step, fill=fill
+        )
     if algorithm == "sdss":
         return uncentered_operator(X, prox_sdss_symmetry, center, step=step, fill=fill)
     if algorithm == "soft" or algorithm == "kspace" and shift is None:
         # If there is no shift then the symmetry is exact and we can just use
         # the soft symmetry algorithm
-        return uncentered_operator(X, prox_soft_symmetry, center, step=step, strength=strength, fill=fill)
+        return uncentered_operator(
+            X, prox_soft_symmetry, center, step=step, strength=strength, fill=fill
+        )
 
     msg = "algorithm must be one of 'soft', 'sdss', 'kspace', recieved '{0}''"
     raise ValueError(msg.format(algorithm))
@@ -323,12 +347,12 @@ def prox_uncentered_symmetry(X, step, center=None, algorithm="kspace", fill=None
 
 def proj(A, B):
     """Returns the projection of A onto the hyper-plane defined by B"""
-    return A - (A*B).sum()*B/(B**2).sum()
+    return A - (A * B).sum() * B / (B ** 2).sum()
 
 
 def proj_dist(A, B):
     """Returns length of projection of A onto B"""
-    return (A*B).sum()/(B**2).sum()**0.5
+    return (A * B).sum() / (B ** 2).sum() ** 0.5
 
 
 def use_relevant_dim(Y, Q, Vs, index):
@@ -351,7 +375,7 @@ def find_relevant_dim(Y, Q, Vs):
         Y_p = proj_dist(Y, Vs[i])
         Q_p = proj_dist(Q, Vs[i])
         if Y_p < 0:
-            t = -Y_p/(Q_p - Y_p)
+            t = -Y_p / (Q_p - Y_p)
         else:
             t = -2
         if t > max_t:
@@ -364,7 +388,7 @@ def find_Q(Vs, n):
     """Finds a Q that is within the solution space that can act as an appropriate target
     (could be rigorously constructed later)"""
     res = np.zeros(n)
-    res[int((n-1)/2)] = n
+    res[int((n - 1) / 2)] = n
     return res
 
 
@@ -385,10 +409,10 @@ def project_disk_sed_mean(bulge_sed, disk_sed):
     """
     new_sed = disk_sed.copy()
     diff = bulge_sed - disk_sed
-    slope = (diff[-1]-diff[0])/(len(bulge_sed)-1)
-    for s in range(1, len(diff)-1):
-        if diff[s] < diff[s-1]:
-            new_sed[s] = bulge_sed[s] - (slope*s + diff[0])
+    slope = (diff[-1] - diff[0]) / (len(bulge_sed) - 1)
+    for s in range(1, len(diff) - 1):
+        if diff[s] < diff[s - 1]:
+            new_sed[s] = bulge_sed[s] - (slope * s + diff[0])
             diff[s] = bulge_sed[s] - new_sed[s]
     return new_sed
 
@@ -411,10 +435,10 @@ def project_disk_sed(bulge_sed, disk_sed):
     """
     new_sed = disk_sed.copy()
     diff = bulge_sed - disk_sed
-    for s in range(1, len(diff)-1):
-        if diff[s] < diff[s-1]:
-            new_sed[s] = new_sed[s] + diff[s-1]
-            diff[s] = diff[s-1]
+    for s in range(1, len(diff) - 1):
+        if diff[s] < diff[s - 1]:
+            new_sed[s] = new_sed[s] + diff[s - 1]
+            diff[s] = diff[s - 1]
     return new_sed
 
 
@@ -442,7 +466,7 @@ def getOffsets(width, coords=None):
     # Use the neighboring pixels by default
     if coords is None:
         coords = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
-    offsets = [width*y+x for y, x in coords]
+    offsets = [width * y + x for y, x in coords]
     slices = [slice(None, s) if s < 0 else slice(s, None) for s in offsets]
     slicesInv = [slice(-s, None) if s < 0 else slice(None, -s) for s in offsets]
     return offsets, slices, slicesInv
@@ -483,12 +507,12 @@ def diagonalizeArray(arr, shape=None, dtype=np.float64):
     # (for example, a pixel on the left edge should not be connected to the
     # pixel to its immediate left in the flattened vector, since that pixel
     # is actual the far right pixel on the row above it).
-    mask[0][np.arange(1, height)*width] = 1
-    mask[2][np.arange(height)*width-1] = 1
-    mask[3][np.arange(1, height)*width] = 1
-    mask[4][np.arange(1, height)*width-1] = 1
-    mask[5][np.arange(height)*width] = 1
-    mask[7][np.arange(1, height-1)*width-1] = 1
+    mask[0][np.arange(1, height) * width] = 1
+    mask[2][np.arange(height) * width - 1] = 1
+    mask[3][np.arange(1, height) * width] = 1
+    mask[4][np.arange(1, height) * width - 1] = 1
+    mask[5][np.arange(height) * width] = 1
+    mask[7][np.arange(1, height - 1) * width - 1] = 1
 
     return diagonals, mask
 
@@ -501,6 +525,7 @@ def diagonalsToSparse(diagonals, shape, dtype=np.float64):
     See `diagonalizeArray` for the details of the 8xN array.
     """
     import scipy.sparse
+
     height, width = shape
     offsets, slices, slicesInv = getOffsets(width)
     diags = [diag[slicesInv[n]] for n, diag in enumerate(diagonals)]
@@ -515,9 +540,8 @@ def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None
     to the peak. In order to quickly create this using sparse matrices, its construction is a bit opaque.
     """
     if center is None:
-        center = ((shape[0]-1) // 2, (shape[1]-1) // 2)
+        center = ((shape[0] - 1) // 2, (shape[1] - 1) // 2)
     name = "RadialMonotonicWeights"
-
 
     key = tuple(shape) + tuple(center) + (useNearest, minGradient)
     try:
@@ -533,12 +557,12 @@ def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None
         X, Y = np.meshgrid(x, y)
         X = X - px
         Y = Y - py
-        distance = np.sqrt(X**2+Y**2)
+        distance = np.sqrt(X ** 2 + Y ** 2)
 
         # Find each pixels neighbors further from the peak and mark them as invalid
         # (to be removed later)
         distArr, mask = diagonalizeArray(distance, dtype=np.float64)
-        relativeDist = (distance.flatten()[:, None]-distArr.T).T
+        relativeDist = (distance.flatten()[:, None] - distArr.T).T
         invalidPix = relativeDist <= 0
 
         # Calculate the angle between each pixel and the x axis, relative to the peak position
@@ -547,23 +571,25 @@ def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None
         tX = X.copy()
         tX[inf] = 1
         angles = np.arctan2(-Y, -tX)
-        angles[inf & (Y != 0)] = 0.5*np.pi*np.sign(angles[inf & (Y != 0)])
+        angles[inf & (Y != 0)] = 0.5 * np.pi * np.sign(angles[inf & (Y != 0)])
 
         # Calcualte the angle between each pixel and it's neighbors
         xArr, m = diagonalizeArray(X)
         yArr, m = diagonalizeArray(Y)
-        dx = (xArr.T-X.flatten()[:, None]).T
-        dy = (yArr.T-Y.flatten()[:, None]).T
+        dx = (xArr.T - X.flatten()[:, None]).T
+        dy = (yArr.T - Y.flatten()[:, None]).T
         # Avoid dividing by zero and set the tan(infinity) pixel values to pi/2 manually
         inf = dx == 0
         dx[inf] = 1
         relativeAngles = np.arctan2(dy, dx)
-        relativeAngles[inf & (dy != 0)] = 0.5*np.pi*np.sign(relativeAngles[inf & (dy != 0)])
+        relativeAngles[inf & (dy != 0)] = (
+            0.5 * np.pi * np.sign(relativeAngles[inf & (dy != 0)])
+        )
 
         # Find the difference between each pixels angle with the peak
         # and the relative angles to its neighbors, and take the
         # cos to find its neighbors weight
-        dAngles = (angles.flatten()[:, None]-relativeAngles.T).T
+        dAngles = (angles.flatten()[:, None] - relativeAngles.T).T
         cosWeight = np.cos(dAngles)
         # Mask edge pixels, array elements outside the operator (for offdiagonal bands with < N elements),
         # and neighbors further from the peak than the reference pixel
@@ -575,16 +601,16 @@ def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None
             cosNorm = np.zeros_like(cosWeight)
             columnIndices = np.arange(cosWeight.shape[1])
             maxIndices = np.argmax(cosWeight, axis=0)
-            indices = maxIndices*cosNorm.shape[1]+columnIndices
+            indices = maxIndices * cosNorm.shape[1] + columnIndices
             indices = np.unravel_index(indices, cosNorm.shape)
             cosNorm[indices] = minGradient
             # Remove the reference for the peak pixel
-            cosNorm[:, px+py*shape[1]] = 0
+            cosNorm[:, px + py * shape[1]] = 0
         else:
             # Normalize the cos weights for each pixel
             normalize = np.sum(cosWeight, axis=0)
             normalize[normalize == 0] = 1
-            cosNorm = (cosWeight.T/normalize[:, None]).T
+            cosNorm = (cosWeight.T / normalize[:, None]).T
             cosNorm[mask] = 0
 
         Cache.set(name, key, cosNorm)
@@ -611,14 +637,14 @@ def getRadialMonotonicOp(shape, useNearest=True, minGradient=1, subtract=True):
 
         # The identity with the peak pixel removed represents the reference pixels
         # Center on the center pixel
-        px = int(shape[1]/2)
-        py = int(shape[0]/2)
+        px = int(shape[1] / 2)
+        py = int(shape[0] / 2)
         # Calculate the distance between each pixel and the peak
-        size = shape[0]*shape[1]
+        size = shape[0] * shape[1]
         diagonal = np.ones(size)
-        diagonal[px+py*shape[1]] = -1
+        diagonal[px + py * shape[1]] = -1
         if subtract:
-            monotonic = cosArr-scipy.sparse.diags(diagonal, offsets=0)
+            monotonic = cosArr - scipy.sparse.diags(diagonal, offsets=0)
         else:
             monotonic = cosArr
         monotonic = MatrixAdapter(monotonic.tocoo(), axis=1)

--- a/scarlet/parameter.py
+++ b/scarlet/parameter.py
@@ -3,6 +3,7 @@ from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.core import VSpace
 from functools import partial
 
+
 class Parameter(np.ndarray):
     """Optimization parameter
 
@@ -26,7 +27,17 @@ class Parameter(np.ndarray):
     fixed: bool
         Whether parameter is held fixed (excluded) during optimization
     """
-    def __new__(cls, array, prior=None, constraint=None, step=0, converged=False, std=None, fixed=False):
+
+    def __new__(
+        cls,
+        array,
+        prior=None,
+        constraint=None,
+        step=0,
+        converged=False,
+        std=None,
+        fixed=False,
+    ):
         obj = np.asarray(array, dtype=array.dtype).view(cls)
         obj.prior = prior
         obj.constraint = constraint
@@ -37,13 +48,14 @@ class Parameter(np.ndarray):
         return obj
 
     def __array_finalize__(self, obj):
-        if obj is None: return
-        self.prior = getattr(obj, 'prior', None)
-        self.constraint = getattr(obj, 'constraint', None)
-        self.step = getattr(obj, 'step_size', 0)
-        self.converged = getattr(obj, 'converged', False)
-        self.std = getattr(obj, 'std', None)
-        self.fixed = getattr(obj, 'fixed', False)
+        if obj is None:
+            return
+        self.prior = getattr(obj, "prior", None)
+        self.constraint = getattr(obj, "constraint", None)
+        self.step = getattr(obj, "step_size", 0)
+        self.converged = getattr(obj, "converged", False)
+        self.std = getattr(obj, "std", None)
+        self.fixed = getattr(obj, "fixed", False)
 
     def __reduce__(self):
         # Get the parent's __reduce__ tuple
@@ -68,5 +80,6 @@ class Parameter(np.ndarray):
 ArrayBox.register(Parameter)
 VSpace.register(Parameter, vspace_maker=VSpace.mappings[np.ndarray])
 
+
 def relative_step(X, it, factor=0.1):
-    return factor*X.mean(axis=0)
+    return factor * X.mean(axis=0)

--- a/scarlet/psf.py
+++ b/scarlet/psf.py
@@ -2,6 +2,7 @@ import autograd.numpy as np
 import autograd.scipy as scipy
 from .bbox import Box
 
+
 def moffat(y, x, alpha=4.7, beta=1.5, bbox=None):
     """Symmetric 2D Moffat function
 
@@ -32,7 +33,8 @@ def moffat(y, x, alpha=4.7, beta=1.5, bbox=None):
     X = np.arange(bbox.shape[2]) + bbox.origin[2]
     X, Y = np.meshgrid(X, Y)
     # TODO: has no pixel-integration formula
-    return ((1+((X-x)**2+(Y-y)**2)/alpha**2)**-beta)[None,:,:]
+    return ((1 + ((X - x) ** 2 + (Y - y) ** 2) / alpha ** 2) ** -beta)[None, :, :]
+
 
 def gaussian(y, x, sigma=1, integrate=True, bbox=None):
     """Circular Gaussian Function
@@ -61,12 +63,19 @@ def gaussian(y, x, sigma=1, integrate=True, bbox=None):
 
     def f(X):
         if not integrate:
-            return np.exp(-X**2/(2*sigma**2))
+            return np.exp(-(X ** 2) / (2 * sigma ** 2))
         else:
             sqrt2 = np.sqrt(2)
-            return np.sqrt(np.pi/2) * sigma * (scipy.special.erf((0.5 - X)/(sqrt2 * sigma)) + scipy.special.erf((2*X + 1)/(2*sqrt2*sigma)))
+            return (
+                np.sqrt(np.pi / 2)
+                * sigma
+                * (
+                    scipy.special.erf((0.5 - X) / (sqrt2 * sigma))
+                    + scipy.special.erf((2 * X + 1) / (2 * sqrt2 * sigma))
+                )
+            )
 
-    return (f(Y-y)[:,None] * f(X-x)[None,:])[None,:,:]
+    return (f(Y - y)[:, None] * f(X - x)[None, :])[None, :, :]
 
 
 class PSF:
@@ -80,13 +89,14 @@ class PSF:
     shape: tuple
         Shape of the 2D image to generate an PSF image for. Only used if `X` is a method.
     """
+
     def __init__(self, X, shape=None):
-        if hasattr(X, 'shape'):
+        if hasattr(X, "shape"):
             self._image = X.copy()
             self.normalize()
             self._func = None
             self.shape = X.shape
-        elif hasattr(X, '__call__'):
+        elif hasattr(X, "__call__"):
             assert shape is not None, "Functional PSFs must set shape argument"
             self._image = None
             self._func = X

--- a/scarlet/resampling.py
+++ b/scarlet/resampling.py
@@ -1,7 +1,10 @@
 import numpy as np
 
-def match_patches(shape_hr, shape_lr, wcs_hr, wcs_lr, isrot = True, perimeter  = 'overlap', psf = False):
-    '''Matches datasets at different resolutions
+
+def match_patches(
+    shape_hr, shape_lr, wcs_hr, wcs_lr, isrot=True, perimeter="overlap", psf=False
+):
+    """Matches datasets at different resolutions
 
     Finds the region of overlap between two datasets and creates a mask for the region as well as the pixel coordinates
     for the dataset pixels inside the overlap.
@@ -23,30 +26,31 @@ def match_patches(shape_hr, shape_lr, wcs_hr, wcs_lr, isrot = True, perimeter  =
         coordinates of the matching pixels at low resolution in the high resolution frame.
     coordhr_hr: array
         coordinates of the high resolution pixels in the overlap. Necessary for psf matching
-    '''
+    """
 
-    assert perimeter in ['overlap', 'union'], 'perimeter should be either overlap or union.'
+    assert perimeter in [
+        "overlap",
+        "union",
+    ], "perimeter should be either overlap or union."
     if psf == True:
-        perimeter == 'overlap'
+        perimeter == "overlap"
 
     if np.size(shape_hr) == 3:
         B_hr, Ny_hr, Nx_hr = shape_hr
     elif np.size(shape_hr) == 2:
         Ny_hr, Nx_hr = shape_hr
     else:
-        raise ValueError('Wrong dimensions for reference image')
+        raise ValueError("Wrong dimensions for reference image")
 
     if np.size(shape_lr) == 3:
         B_lr, Ny_lr, Nx_lr = shape_lr
     elif np.size(shape_lr) == 2:
         Ny_lr, Nx_lr = shape_lr
     else:
-        raise ValueError('Wrong dimensions for low resolution image')
+        raise ValueError("Wrong dimensions for low resolution image")
 
     assert wcs_hr != None
     assert wcs_lr != None
-
-
 
     y_hr, x_hr = np.array(range(Ny_hr)), np.array(range(Nx_hr))
 
@@ -62,13 +66,13 @@ def match_patches(shape_hr, shape_lr, wcs_hr, wcs_lr, isrot = True, perimeter  =
     else:
         Y_lr, X_lr = np.array(range(Ny_lr)), np.array(range(Nx_lr))
 
-    #Corresponding angular positions
-    #of low resolution pixels
+    # Corresponding angular positions
+    # of low resolution pixels
     if np.size(wcs_lr.array_shape) == 2:
         ra_lr, dec_lr = wcs_lr.all_pix2world(X_lr, Y_lr, 0, ra_dec_order=True)
     elif np.size(wcs_lr.array_shape) == 3:
         ra_lr, dec_lr = wcs_lr.all_pix2world(X_lr, Y_lr, 0, 0, ra_dec_order=True)
-    #of high resolution pixels
+    # of high resolution pixels
     if np.size(wcs_hr.array_shape) == 2:
         ra_hr, dec_hr = wcs_hr.all_pix2world(x_hr, y_hr, 0, ra_dec_order=True)
     elif np.size(wcs_hr.array_shape) == 3:
@@ -86,24 +90,25 @@ def match_patches(shape_hr, shape_lr, wcs_hr, wcs_lr, isrot = True, perimeter  =
     elif np.size(wcs_lr.array_shape) == 3:
         x_lr, y_lr, _ = wcs_lr.all_world2pix(ra_hr, dec_hr, 0, 0, ra_dec_order=True)
 
-    #mask of low resolution pixels at high resolution in the overlap:
-    over_lr = ((X_hr >= 0) * (X_hr < Nx_hr+1) * (Y_hr >= 0) * (Y_hr < Ny_hr+1))
-    #mask of high resolution pixels at low resolution in the overlap (needed for psf matching)
-    over_hr = ((x_lr >= 0) * (x_lr < Nx_lr+1) * (y_lr >= 0) * (y_lr < Ny_lr+1))
+    # mask of low resolution pixels at high resolution in the overlap:
+    over_lr = (X_hr >= 0) * (X_hr < Nx_hr + 1) * (Y_hr >= 0) * (Y_hr < Ny_hr + 1)
+    # mask of high resolution pixels at low resolution in the overlap (needed for psf matching)
+    over_hr = (x_lr >= 0) * (x_lr < Nx_lr + 1) * (y_lr >= 0) * (y_lr < Ny_lr + 1)
 
-    #pixels of the high resolution frame in the overlap in high resolution frame (needed for PSF only)
+    # pixels of the high resolution frame in the overlap in high resolution frame (needed for PSF only)
     coordhr_hr = (y_hr[(over_hr == 1)], x_hr[(over_hr == 1)])
 
     class SourceInitError(Exception):
         """
         Datasets do not match, no overlap found. Check the coordinates of the observations or the WCS.
         """
+
         pass
 
     if np.sum(over_lr) == 0:
         raise SourceInitError
 
-    if perimeter is 'overlap':
+    if perimeter is "overlap":
         # Coordinates of low resolution pixels in the overlap at low resolution:
         ylr_lr = Y_lr[(over_lr == 1)]
         xlr_lr = X_lr[(over_lr == 1)]
@@ -114,7 +119,7 @@ def match_patches(shape_hr, shape_lr, wcs_hr, wcs_lr, isrot = True, perimeter  =
 
         coordlr_hr = (ylr_hr, xlr_hr)
 
-    elif perimeter is 'union':
+    elif perimeter is "union":
 
         # Coordinates of low resolution pixels at low resolution:
         coordlr_lr = (Y_lr, X_lr)
@@ -123,4 +128,3 @@ def match_patches(shape_hr, shape_lr, wcs_hr, wcs_lr, isrot = True, perimeter  =
         coordlr_hr = (Y_hr, X_hr)
 
     return coordlr_lr, coordlr_hr, coordhr_hr
-


### PR DESCRIPTION
This PR has no functionality change. It reformats the code to PEP8 by using [black](https://black.readthedocs.io/en/latest/index.html). I also added an automated pre-commit hook to maintain PEP8-compliance automatically. Install instructions are [here](https://black.readthedocs.io/en/latest/version_control_integration.html)