### PR TITLE
made BBox any-dimensional

### DIFF
--- a/docs/1-concepts.ipynb
+++ b/docs/1-concepts.ipynb
@@ -180,16 +180,16 @@
     "\n",
     "for k,src in enumerate(sources):\n",
     "    for p in src.parameters:\n",
-    "        print (\"Source {}, Parameter shape {}, Converged {}\".format(k, p.shape, p.converged))"
+    "        print (\"Source {}: {}, Parameter {}, Converged {}\".format(k, src.__class__, p.name, p.converged))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The parameter with length 5 is the SED, while the other describes the morphology. For object 0, this is simply a 2D center, the rest use images of different sizes.\n",
+    "Source 0 is a `PointSource`, parameterized by a SED and a center and a sed center. Source 1 has multiple components (each with a SED and a free-form morphology), the rest have a SED and morphology each.\n",
     "\n",
-    "Each parameter is a souped up `numpy` array. It has a value as well as additonal attributes that store a `prior` and `constraint` that were enforced during optimization; the typical `step` size during optimization; whether this parameter is considered `converged`; an estimate of the standard deviate `std`; and whether the parameter was held `fixed`:"
+    "`Parameter` is a souped up `numpy` array. It has a value and a name, as well as additonal attributes that store a `prior` and `constraint` that were enforced during optimization; the typical `step` size during optimization; whether this parameter is considered `converged`; an estimate of the standard deviate `std`; and whether the parameter was held `fixed`:"
    ]
   },
   {

--- a/scarlet/bbox.py
+++ b/scarlet/bbox.py
@@ -11,22 +11,17 @@ class Box:
     Parameters
     ----------
     shape: tuple
-        Size of the box in depth,height,width
+        Size of the box
     origin: tuple
-        Minimum (z,y,x) value of the box (front low left corner).
+        Front/low/left corner coordinate of the box
     """
 
-    def __init__(self, shape, origin=(0, 0, 0)):
-        # bbox always in 3D
-        if len(shape) == 2:
-            shape = (0, *shape)
-        assert len(shape) == 3
-        self.shape = shape
-
-        if len(origin) == 2:
-            origin = (0, *origin)
-        assert len(origin) == 3
-        self.origin = origin
+    def __init__(self, shape, origin=None):
+        self.shape = tuple(shape)
+        if origin is None:
+            origin = (0,) * len(shape)
+        assert len(origin) == len(shape)
+        self.origin = tuple(origin)
 
     @staticmethod
     def from_image(image):
@@ -35,7 +30,6 @@ class Box:
         Parameters
         ----------
         image: array-like
-            2D image
 
         Returns
         -------
@@ -45,34 +39,24 @@ class Box:
         return Box(image.shape)
 
     @staticmethod
-    def from_bounds(front, back, bottom, top, left, right):
+    def from_bounds(*args):
         """Initialize a box from its bounds
 
         Parameters
         ----------
-        bottom: int
-            Minimum in the y direction.
-        top: int
-            Maximum in the y direction.
-        left: int
-            Minimum in the x direction.
-        right: int
-            Maximum in the x direction.
+        args: ints
+            Min/Max coordinate for every dimension
 
         Returns
         -------
         bbox: :class:`scarlet.bbox.Box`
             A new box bounded by the input bounds.
         """
-        if back < front:
-            back, front = front, back
-        if top < bottom:
-            top, bottom = bottom, top
-        if right < left:
-            right, left = left, right
-        return Box(
-            (back - front, top - bottom, right - left), origin=(front, bottom, left)
-        )
+        assert len(args) % 2 == 0
+        dims = len(args) // 2
+        shape = [args[dim * 2 + 1] - args[dim * 2] for dim in range(dims)]
+        origin = [args[dim * 2] for dim in range(dims)]
+        return Box(shape, origin=origin)
 
     @staticmethod
     def from_data(X, min_value=0):
@@ -88,7 +72,7 @@ class Box:
         Returns
         -------
         bbox: :class:`scarlet.bbox.Box`
-            Bounding box for the thresholded `X` (bottom, top, left, right)
+            Bounding box for the thresholded `X`
         """
         sel = X > min_value
         if sel.any():
@@ -97,20 +81,16 @@ class Box:
             for dim in range(len(X.shape)):
                 bounds.append(nonzero[dim].min())
                 bounds.append(nonzero[dim].max() + 1)
-            if len(X.shape) == 2:
-                bounds.insert(0, 0)
-                bounds.insert(1, 0)
         else:
-            bounds = [0] * 6
+            bounds = [0,] * len(X.shape) * 2
         return Box.from_bounds(*bounds)
 
     def contains(self, p):
         """Whether the box cotains a given coordinate `p`
         """
-        if len(p) == 2:
-            p = (0, *p)
+        assert len(p) == self.D
 
-        for d in range(len(self.shape)):
+        for d in range(self.D):
             if p[d] < self.origin[d] or p[d] > self.origin[d] + self.shape[d]:
                 return False
         return True
@@ -125,27 +105,17 @@ class Box:
 
         Returns
         -------
-        If shape is 2D: `slice_y`, `slice_x`
-        If shape is 3: `slice(None)`, `slice_y`, `slice_x`
+        slices for every dimension
         """
         if hasattr(im_or_shape, "shape"):
             shape = im_or_shape.shape
         else:
             shape = im_or_shape
-        assert len(shape) in [2, 3]
+        assert len(shape) == self.D
 
         im_box = Box(shape)
         overlap = self & im_box
-        zslice, yslice, xslice = (
-            slice(overlap.front, overlap.back),
-            slice(overlap.bottom, overlap.top),
-            slice(overlap.left, overlap.right),
-        )
-
-        if len(shape) == 2:
-            return yslice, xslice
-        else:
-            return zslice, yslice, xslice
+        return tuple(slice(overlap.start[d], overlap.stop[d]) for d in range(self.D))
 
     def extract_from(self, image, sub=None):
         """Extract sub-image described by this bbox from image
@@ -164,10 +134,7 @@ class Box:
         imbox = Box.from_image(image)
 
         if sub is None:
-            if len(image.shape) == 3:
-                sub = np.zeros(self.shape)
-            else:
-                sub = np.zeros(self.shape[1:])
+            sub = np.zeros(self.shape)
         subbox = Box.from_image(sub)
 
         # imbox now in the frame of this bbox (i.e. of box)
@@ -202,58 +169,22 @@ class Box:
         return image
 
     @property
-    def C(self):
-        """Number of channels in the model
+    def D(self):
+        """Dimensionality of this BBox
         """
-        return self.shape[0]
+        return len(self.shape)
 
     @property
-    def Ny(self):
-        """Number of pixel in the y-direction
+    def start(self):
+        """Tuple of start coordinates
         """
-        return self.shape[1]
+        return self.origin
 
     @property
-    def Nx(self):
-        """Number of pixels in the x-direction
+    def stop(self):
+        """Tuple of stop coordinates (last is included)
         """
-        return self.shape[2]
-
-    @property
-    def front(self):
-        """Minimum z value
-        """
-        return self.origin[0]
-
-    @property
-    def bottom(self):
-        """Minimum y value
-        """
-        return self.origin[1]
-
-    @property
-    def left(self):
-        """Minimum x value
-        """
-        return self.origin[2]
-
-    @property
-    def back(self):
-        """Maximum y value
-        """
-        return self.origin[0] + self.shape[0]
-
-    @property
-    def top(self):
-        """Maximum y value
-        """
-        return self.origin[1] + self.shape[1]
-
-    @property
-    def right(self):
-        """Maximum x value
-        """
-        return self.origin[2] + self.shape[2]
+        return tuple(o + s for o, s in zip(self.origin, self.shape))
 
     def __or__(self, other):
         """Union of two bounding boxes
@@ -268,13 +199,12 @@ class Box:
         result: `Box`
             The smallest rectangular box that contains *both* boxes.
         """
-        front = min(self.front, other.front)
-        back = max(self.back, other.back)
-        bottom = min(self.bottom, other.bottom)
-        top = max(self.top, other.top)
-        left = min(self.left, other.left)
-        right = max(self.right, other.right)
-        return Box.from_bounds(front, back, bottom, top, left, right)
+        assert other.D == self.D
+        bounds = []
+        for d in range(self.D):
+            bounds.append(min(self.start[d], other.start[d]))
+            bounds.append(max(self.stop[d], other.stop[d]))
+        return Box.from_bounds(*bounds)
 
     def __and__(self, other):
         """Intersection of two bounding boxes
@@ -293,18 +223,12 @@ class Box:
             The rectangular box that is in the overlap region
             of both boxes.
         """
-        front = max(self.front, other.front)
-        back = min(self.back, other.back)
-        bottom = max(self.bottom, other.bottom)
-        top = min(self.top, other.top)
-        left = max(self.left, other.left)
-        right = min(self.right, other.right)
-        return Box.from_bounds(front, back, bottom, top, left, right)
-
-    def __str__(self):
-        return "Box({0}..{1}, {2}..{3}, {4}..{5})".format(
-            self.front, self.back, self.bottom, self.top, self.left, self.right
-        )
+        assert other.D == self.D
+        bounds = []
+        for d in range(self.D):
+            bounds.append(max(self.start[d], other.start[d]))
+            bounds.append(min(self.stop[d], other.stop[d]))
+        return Box.from_bounds(*bounds)
 
     def __repr__(self):
         result = "<Box shape={0}, origin={1}>"

--- a/scarlet/component.py
+++ b/scarlet/component.py
@@ -122,30 +122,21 @@ class Component(ABC):
             # determine pad from box into full frame
             # yields superset of frame pixels
             # pad_width is ((before1, after1), (before2, after2)...)
-            self.pad_width = (
+            self.pad_width = list(
                 (
-                    max(0, self.bbox.front - self.frame.front),
-                    max(0, self.frame.back - self.bbox.back),
-                ),
-                (
-                    max(0, self.bbox.bottom - self.frame.bottom),
-                    max(0, self.frame.top - self.bbox.top),
-                ),
-                (
-                    max(0, self.bbox.left - self.frame.left),
-                    max(0, self.frame.right - self.bbox.right),
-                ),
+                    max(0, self.bbox.start[d] - self.frame.start[d]),
+                    max(0, self.frame.stop[d] - self.bbox.stop[d]),
+                )
+                for d in range(self.frame.D)
             )
 
             # get slicing of padded box so that the result covers
             # all of the model frame
-            front = self.bbox.front - self.pad_width[0][0]
-            back = self.bbox.back + self.pad_width[0][1]
-            bottom = self.bbox.bottom - self.pad_width[1][0]
-            top = self.bbox.top + self.pad_width[1][1]
-            left = self.bbox.left - self.pad_width[2][0]
-            right = self.bbox.right + self.pad_width[2][1]
-            padded_box = Box.from_bounds(front, back, bottom, top, left, right)
+            bounds = []
+            for d in range(self.frame.D):
+                bounds.append(self.bbox.start[d] - self.pad_width[d][0])
+                bounds.append(self.bbox.stop[d] + self.pad_width[d][1])
+            padded_box = Box.from_bounds(*bounds)
 
             model_box = self.frame
             overlap = model_box & padded_box

--- a/scarlet/component.py
+++ b/scarlet/component.py
@@ -134,8 +134,12 @@ class Component(ABC):
             # all of the model frame
             bounds = []
             for d in range(self.frame.D):
-                bounds.append(self.bbox.start[d] - self.pad_width[d][0])
-                bounds.append(self.bbox.stop[d] + self.pad_width[d][1])
+                bounds.append(
+                    (
+                        self.bbox.start[d] - self.pad_width[d][0],
+                        self.bbox.stop[d] + self.pad_width[d][1],
+                    )
+                )
             padded_box = Box.from_bounds(*bounds)
 
             model_box = self.frame

--- a/scarlet/display.py
+++ b/scarlet/display.py
@@ -349,8 +349,8 @@ def show_sources(
             model = src.get_model()
             model = observation.render(model)
             ax[k][panel].imshow(img_to_rgb(model, norm=norm, channel_map=channel_map))
-            ax[k][panel].set_xlim(src.bbox.left, src.bbox.right)
-            ax[k][panel].set_ylim(src.bbox.bottom, src.bbox.top)
+            ax[k][panel].set_ylim(src.bbox.start[-2], src.bbox.stop[-2])
+            ax[k][panel].set_xlim(src.bbox.start[-1], src.bbox.stop[-1])
             ax[k][panel].set_title("Model Source {} Rendered".format(k))
             if center is not None:
                 ax[k][panel].plot(*center__[::-1], "wx", mew=1, ms=10)
@@ -360,8 +360,8 @@ def show_sources(
             ax[k][panel].imshow(
                 img_to_rgb(observation.images, norm=norm, channel_map=channel_map)
             )
-            ax[k][panel].set_xlim(src.bbox.left, src.bbox.right)
-            ax[k][panel].set_ylim(src.bbox.bottom, src.bbox.top)
+            ax[k][panel].set_ylim(src.bbox.start[-2], src.bbox.stop[-2])
+            ax[k][panel].set_xlim(src.bbox.start[-1], src.bbox.stop[-1])
             ax[k][panel].set_title("Observation".format(k))
             if center is not None:
                 ax[k][panel].plot(*center__[::-1], "wx", mew=1, ms=10)

--- a/scarlet/frame.py
+++ b/scarlet/frame.py
@@ -49,6 +49,24 @@ class Frame(Box):
         self.dtype = dtype
 
     @property
+    def C(self):
+        """Number of channels in the model
+        """
+        return self.shape[0]
+
+    @property
+    def Ny(self):
+        """Number of pixel in the y-direction
+        """
+        return self.shape[1]
+
+    @property
+    def Nx(self):
+        """Number of pixels in the x-direction
+        """
+        return self.shape[2]
+
+    @property
     def psf(self):
         return self._psfs
 

--- a/scarlet/observation.py
+++ b/scarlet/observation.py
@@ -451,12 +451,9 @@ class LowResObservation(Observation):
             cmin, cmax = 0, self.frame.C
         # 2) use the bounds of coord_lr
         self.bbox = Box.from_bounds(
-            cmin,
-            cmax + 1,
-            np.min(coord_lr[0]).astype(int),
-            np.max(coord_lr[0]).astype(int) + 1,
-            np.min(coord_lr[1]).astype(int),
-            np.max(coord_lr[1]).astype(int) + 1,
+            (cmin, cmax + 1),
+            (np.min(coord_lr[0]).astype(int), np.max(coord_lr[0]).astype(int) + 1),
+            (np.min(coord_lr[1]).astype(int), np.max(coord_lr[1]).astype(int) + 1),
         )
         self.slices = self.bbox.slices_for(model_frame.shape)
         # Coordinates for all model frame pixels

--- a/scarlet/parameter.py
+++ b/scarlet/parameter.py
@@ -11,6 +11,8 @@ class Parameter(np.ndarray):
     ----------
     array: array-like
         numpy array (type float) to hold parameter values
+    name: string
+        Name to identify parameter
     prior: `~scarlet.Prior`
         Prior distribution for parameter
     constraint: `~scarlet.Constraint`
@@ -31,6 +33,7 @@ class Parameter(np.ndarray):
     def __new__(
         cls,
         array,
+        name="unnamed",
         prior=None,
         constraint=None,
         step=0,
@@ -39,6 +42,7 @@ class Parameter(np.ndarray):
         fixed=False,
     ):
         obj = np.asarray(array, dtype=array.dtype).view(cls)
+        obj.name = name
         obj.prior = prior
         obj.constraint = constraint
         obj.step = step
@@ -50,6 +54,7 @@ class Parameter(np.ndarray):
     def __array_finalize__(self, obj):
         if obj is None:
             return
+        self.name = getattr(obj, "name", "unnamed")
         self.prior = getattr(obj, "prior", None)
         self.constraint = getattr(obj, "constraint", None)
         self.step = getattr(obj, "step_size", 0)

--- a/scarlet/parameter.py
+++ b/scarlet/parameter.py
@@ -2,6 +2,8 @@ import autograd.numpy as np
 from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.core import VSpace
 from functools import partial
+from .constraint import Constraint, ConstraintChain
+from .prior import Prior
 
 
 class Parameter(np.ndarray):
@@ -43,7 +45,13 @@ class Parameter(np.ndarray):
     ):
         obj = np.asarray(array, dtype=array.dtype).view(cls)
         obj.name = name
+        if prior is not None:
+            assert isinstance(prior, Prior)
         obj.prior = prior
+        if constraint is not None:
+            assert isinstance(constraint, Constraint) or isinstance(
+                constraint, ConstraintChain
+            )
         obj.constraint = constraint
         obj.step = step
         obj.converged = converged

--- a/scarlet/prior.py
+++ b/scarlet/prior.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+import numpy as np
+
+
+class Prior(ABC):
+    """Prior base class
+
+    A prior encodes the distribution of valid solutions for optimization parrameters.
+    """
+
+    @abstractmethod
+    def __call__(self, *X):
+        """Compute the log-likelihood of `X` under the prior
+        """
+        pass
+
+    @abstractmethod
+    def grad(self, *X):
+        """Compute the gradients of the log-likelihood of `X` under the prior
+        """
+        pass

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -320,8 +320,10 @@ class RandomSource(FactorizedComponent):
             sed = get_best_fit_seds(morph[None], frame, observation)[0]
 
         constraint = PositivityConstraint()
-        sed = Parameter(sed, step=relative_step, constraint=constraint)
-        morph = Parameter(morph, step=relative_step, constraint=constraint)
+        sed = Parameter(sed, name="sed", step=relative_step, constraint=constraint)
+        morph = Parameter(
+            morph, name="morph", step=relative_step, constraint=constraint
+        )
 
         super().__init__(frame, sed, morph)
 
@@ -375,10 +377,11 @@ class PointSource(FunctionComponent):
         # set up parameters
         sed = Parameter(
             sed,
+            name="sed",
             step=partial(relative_step, factor=1e-2),
             constraint=PositivityConstraint(),
         )
-        center = Parameter(self.center, step=1e-1)
+        center = Parameter(self.center, name="center", step=1e-1)
 
         # define bbox
         pixel_center = tuple(np.round(center).astype("int"))
@@ -437,7 +440,7 @@ class ExtendedSource(FactorizedComponent):
         self.pixel_center = tuple(np.round(center).astype("int"))
 
         if shifting:
-            shift = Parameter(center - self.pixel_center, step=1e-1)
+            shift = Parameter(center - self.pixel_center, name="shift", step=1e-1)
         else:
             shift = None
 
@@ -454,6 +457,7 @@ class ExtendedSource(FactorizedComponent):
 
         sed = Parameter(
             sed,
+            name="sed",
             step=partial(relative_step, factor=1e-2),
             constraint=PositivityConstraint(),
         )
@@ -477,7 +481,7 @@ class ExtendedSource(FactorizedComponent):
         ]
         morph_constraint = ConstraintChain(*constraints)
 
-        morph = Parameter(morph, step=1e-2, constraint=morph_constraint)
+        morph = Parameter(morph, name="morph", step=1e-2, constraint=morph_constraint)
 
         super().__init__(frame, sed, morph, bbox=bbox, shift=shift)
 
@@ -549,7 +553,7 @@ class MultiComponentSource(ComponentTree):
         pixel_center = tuple(np.round(center).astype("int"))
 
         if shifting:
-            shift = Parameter(center - pixel_center, step=1e-1)
+            shift = Parameter(center - pixel_center, name="shift", step=1e-1)
         else:
             shift = None
 
@@ -587,10 +591,13 @@ class MultiComponentSource(ComponentTree):
         for k in range(len(seds)):
             sed = Parameter(
                 seds[k],
+                name="sed",
                 step=partial(relative_step, factor=1e-1),
                 constraint=PositivityConstraint(),
             )
-            morph = Parameter(morphs[k], step=1e-2, constraint=morph_constraint)
+            morph = Parameter(
+                morphs[k], name="morph", step=1e-2, constraint=morph_constraint
+            )
             components.append(
                 FactorizedComponent(frame, sed, morph, bbox=bbox, shift=shift)
             )

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -144,10 +144,10 @@ def trim_morphology(sky_coord, frame, morph, bg_cutoff, thresh):
         if bbox.contains(pixel_center):
             size = 2 * max(
                 (
-                    pixel_center[0] - bbox.start[0],
-                    bbox.stop[0] - pixel_center[0],
-                    pixel_center[1] - bbox.start[1],
-                    bbox.stop[1] - pixel_center[1],
+                    pixel_center[0] - bbox.start[-2],
+                    bbox.stop[0] - pixel_center[-2],
+                    pixel_center[1] - bbox.start[-1],
+                    bbox.stop[1] - pixel_center[-1],
                 )
             )
             while boxsize < size:
@@ -161,9 +161,9 @@ def trim_morphology(sky_coord, frame, morph, bg_cutoff, thresh):
     top = pixel_center[0] + boxsize // 2
     left = pixel_center[1] - boxsize // 2
     right = pixel_center[1] + boxsize // 2
-    bbox = Box.from_bounds(bottom, top, left, right)
+    bbox = Box.from_bounds((bottom, top), (left, right))
     morph = bbox.extract_from(morph)
-    bbox_3d = Box.from_bounds(0, frame.C, bottom, top, left, right)
+    bbox_3d = Box.from_bounds((0, frame.C), (bottom, top), (left, right))
     return morph, bbox_3d
 
 
@@ -387,7 +387,7 @@ class PointSource(FunctionComponent):
         top = pixel_center[0] + frame.psf.shape[1] // 2
         left = pixel_center[1] - frame.psf.shape[2] // 2
         right = pixel_center[1] + frame.psf.shape[2] // 2
-        bbox = Box.from_bounds(front, back, bottom, top, left, right)
+        bbox = Box.from_bounds((front, back), (bottom, top), (left, right))
 
         super().__init__(frame, sed, center, self._psf_wrapper, bbox=bbox)
 

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -144,10 +144,10 @@ def trim_morphology(sky_coord, frame, morph, bg_cutoff, thresh):
         if bbox.contains(pixel_center):
             size = 2 * max(
                 (
-                    pixel_center[0] - bbox.bottom,
-                    bbox.top - pixel_center[0],
-                    pixel_center[1] - bbox.left,
-                    bbox.right - pixel_center[1],
+                    pixel_center[0] - bbox.start[0],
+                    bbox.stop[0] - pixel_center[0],
+                    pixel_center[1] - bbox.start[1],
+                    bbox.stop[1] - pixel_center[1],
                 )
             )
             while boxsize < size:
@@ -161,9 +161,10 @@ def trim_morphology(sky_coord, frame, morph, bg_cutoff, thresh):
     top = pixel_center[0] + boxsize // 2
     left = pixel_center[1] - boxsize // 2
     right = pixel_center[1] + boxsize // 2
-    bbox = Box.from_bounds(0, frame.C, bottom, top, left, right)
+    bbox = Box.from_bounds(bottom, top, left, right)
     morph = bbox.extract_from(morph)
-    return morph, bbox
+    bbox_3d = Box.from_bounds(0, frame.C, bottom, top, left, right)
+    return morph, bbox_3d
 
 
 def init_extended_source(

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1,8 +1,8 @@
 import numpy as np
 import scarlet
 
-class TestBox(object):
 
+class TestBox(object):
     def test_from_data(self):
         x = np.arange(25).reshape(5, 5)
         x[0] = 0
@@ -19,36 +19,36 @@ class TestBox(object):
 
     def test_contains(self):
         bbox = scarlet.Box((6, 4, 3), origin=(0, 1, 0))
-        p = (3,3,3) # corner case: edge is contained
+        p = (2, 2, 2)
         assert bbox.contains(p)
 
-        p = (3,0,3)
+        p = (3, 0, 3)
         assert not bbox.contains(p)
 
-        p = (7,3,3)
+        p = (7, 3, 3)
         assert not bbox.contains(p)
 
-        p = (3,3,-1)
+        p = (3, 3, -1)
         assert not bbox.contains(p)
 
     def test_extract_from(self):
-        image = np.zeros((3,5,5))
-        image[1,1,1] = 1
+        image = np.zeros((3, 5, 5))
+        image[1, 1, 1] = 1
 
         # simple one pixel box extraction
         bbox = scarlet.Box.from_data(image)
         extracted = bbox.extract_from(image)
-        assert extracted.shape == (1,1,1) and extracted[0,0,0] == 1
+        assert extracted.shape == (1, 1, 1) and extracted[0, 0, 0] == 1
 
         # offset box extraction past boundary of image
-        bbox = scarlet.Box.from_bounds(0, 3, -2, 3, -3, 2)
+        bbox = scarlet.Box.from_bounds((0, 3), (-2, 3), (-3, 2))
         extracted = bbox.extract_from(image)
-        assert extracted.shape == (3,5,5) and extracted[1,3,4] == 1
+        assert extracted.shape == (3, 5, 5) and extracted[1, 3, 4] == 1
 
     def test_insert_into(self):
-        image = np.zeros((3,5,5))
-        sub = np.zeros((3,5,5))
-        sub[1,3,4] = 1
-        bbox = scarlet.Box.from_bounds(0, 3, -2, 3, -3, 2)
+        image = np.zeros((3, 5, 5))
+        sub = np.zeros((3, 5, 5))
+        sub[1, 3, 4] = 1
+        bbox = scarlet.Box.from_bounds((0, 3), (-2, 3), (-3, 2))
         image = bbox.insert_into(image, sub)
-        assert image.shape == (3,5,5) and image[1,1,1] == 1
+        assert image.shape == (3, 5, 5) and image[1, 1, 1] == 1


### PR DESCRIPTION
BBox was inelegant because it implicitly assumed or manually forced all boxes to be in 3D. Now it works in any dimension and simply takes its dimensionality from the contained that defined on at init. The only downside is the loss of the `front`, `back`, `left`, `right` etc. properties. On the upside, as Fred and I can attest: there isn't universal agreement on what they mean, so I've chosen the python slicing syntax `start` and `stop` and made it multi-dimensional.