### PR TITLE
Display

### DIFF
--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -276,9 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "scarlet.display.show_sources(sources, \n",
@@ -473,7 +471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/display.ipynb
+++ b/docs/tutorials/display.ipynb
@@ -246,13 +246,6 @@
     "                            )\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/display.ipynb
+++ b/docs/tutorials/display.ipynb
@@ -32,7 +32,7 @@
     "import matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "# use a good colormap and don't interpolate the pixels\n",
-    "matplotlib.rc('image', cmap='inferno', interpolation='none')\n",
+    "matplotlib.rc('image', cmap='inferno', interpolation='none', origin='lower')\n",
     "\n",
     "# Load the sample images\n",
     "data = np.load(\"../../data/hsc_cosmos_35.npz\")\n",
@@ -215,7 +215,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scarlet.display.show_sources(sources, norm=norm, channel_map=channel_map)\n",
+    "scarlet.display.show_sources(sources, \n",
+    "                             norm=norm, \n",
+    "                             channel_map=channel_map, \n",
+    "                             observation=observation,\n",
+    "                             show_rendered=True, \n",
+    "                             show_observed=True)\n",
     "plt.show()"
    ]
   },
@@ -223,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Source 1 is modelled with 2 components, and the SED is shown for them separately. If we wanted to see the images of the components, we can just pass the source itself to `show_sources`. For good measure, we also switch on the rendering and the observation at the same location:"
+    "Source 1 is modelled with 2 components, and the SED is shown for them separately. If we wanted to see the images of the components, we can just pass the source itself to `show_sources`:"
    ]
   },
   {
@@ -267,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/scarlet/display.py
+++ b/scarlet/display.py
@@ -221,11 +221,11 @@ def show_scene(
             figsize = (3 * panels, 3 * len(list(sources)))
         fig, ax = plt.subplots(1, panels, figsize=figsize)
     else:
-        columns = int(np.ceil(panels/2))
+        columns = int(np.ceil(panels / 2))
         if figsize is None:
-            figsize = (7*columns, 4*columns)
+            figsize = (7 * columns, 4 * columns)
         fig = plt.figure(figsize=figsize)
-        ax = [fig.add_subplot(2, columns, n+1) for n in range(panels)]
+        ax = [fig.add_subplot(2, columns, n + 1) for n in range(panels)]
     if not hasattr(ax, "__iter__"):
         ax = (ax,)
 
@@ -239,7 +239,9 @@ def show_scene(
     panel = 0
     tree = ComponentTree(sources)
     model = tree.get_model()
-    ax[panel].imshow(img_to_rgb(model, norm=norm, channel_map=channel_map))
+    ax[panel].imshow(
+        img_to_rgb(model, norm=norm, channel_map=channel_map), origin="lower"
+    )
     ax[panel].set_title("Model")
 
     if show_rendered or show_residual:
@@ -248,7 +250,8 @@ def show_scene(
     if show_rendered:
         panel += 1
         ax[panel].imshow(
-            img_to_rgb(model, norm=norm, channel_map=channel_map, mask=mask)
+            img_to_rgb(model, norm=norm, channel_map=channel_map, mask=mask),
+            origin="lower",
         )
         ax[panel].set_title("Model Rendered")
 
@@ -257,7 +260,8 @@ def show_scene(
         ax[panel].imshow(
             img_to_rgb(
                 observation.images, norm=norm, channel_map=channel_map, mask=mask
-            )
+            ),
+            origin="lower",
         )
         ax[panel].set_title("Observation")
 
@@ -266,7 +270,8 @@ def show_scene(
         residual = observation.images - model
         norm_ = LinearPercentileNorm(residual)
         ax[panel].imshow(
-            img_to_rgb(residual, norm=norm_, channel_map=channel_map, mask=mask)
+            img_to_rgb(residual, norm=norm_, channel_map=channel_map, mask=mask),
+            origin="lower",
         )
         ax[panel].set_title("Residual")
 
@@ -353,7 +358,12 @@ def show_sources(
             model = src.get_model()
             seds = [model.sum(axis=(1, 2))]
         src.set_frame(frame_)
-        ax[k][panel].imshow(img_to_rgb(model, norm=norm, channel_map=channel_map, mask=model.sum(axis=0)==0))
+        ax[k][panel].imshow(
+            img_to_rgb(
+                model, norm=norm, channel_map=channel_map, mask=model.sum(axis=0) == 0
+            ),
+            origin="lower",
+        )
         ax[k][panel].set_title("Model Source {}".format(k))
         if center is not None:
             ax[k][panel].plot(*center_[::-1], "wx", mew=1, ms=10)
@@ -362,7 +372,9 @@ def show_sources(
             panel += 1
             model = src.get_model()
             model = observation.render(model)
-            ax[k][panel].imshow(img_to_rgb(model, norm=norm, channel_map=channel_map))
+            ax[k][panel].imshow(
+                img_to_rgb(model, norm=norm, channel_map=channel_map), origin="lower"
+            )
             ax[k][panel].set_title("Model Source {} Rendered".format(k))
             if src.bbox is not None:
                 ax[k][panel].set_ylim(src.bbox.start[-2], src.bbox.stop[-2])
@@ -373,7 +385,8 @@ def show_sources(
         if show_observed:
             panel += 1
             ax[k][panel].imshow(
-                img_to_rgb(observation.images, norm=norm, channel_map=channel_map)
+                img_to_rgb(observation.images, norm=norm, channel_map=channel_map),
+                origin="lower",
             )
             ax[k][panel].set_title("Observation".format(k))
             if src.bbox is not None:

--- a/scarlet/display.py
+++ b/scarlet/display.py
@@ -359,10 +359,7 @@ def show_sources(
             seds = [model.sum(axis=(1, 2))]
         src.set_frame(frame_)
         ax[k][panel].imshow(
-            img_to_rgb(
-                model, norm=norm, channel_map=channel_map, mask=model.sum(axis=0) == 0
-            ),
-            origin="lower",
+            img_to_rgb(model, norm=norm, channel_map=channel_map), origin="lower",
         )
         ax[k][panel].set_title("Model Source {}".format(k))
         if center is not None:


### PR DESCRIPTION
Minor consistency tweaks in display: 
* origin is always lower (stops weird image flips in docs)
* and models are always unmasked.

On the last point: Observations have masks, our models do no. Also, masking at zero creates a lot of visual noise exactly where nothing relevant happens. The exact location of the zero crossing is noise dominated and largely irrelevant (maybe somewhat meaningful for PSF models). Also, not every model is thresholded at zero, so the plotting code imposes a constraint, which the actual source model may not share.