### PR TITLE
flat monotonicity weighting

### DIFF
--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -276,9 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "scarlet.display.show_sources(sources, \n",
@@ -387,16 +385,16 @@
     "# add two sources at their approximate locations\n",
     "model_frame_ = sources_[0].frame\n",
     "yx = (14., 44.)\n",
-    "new_source = scarlet.ExtendedSource(model_frame_, yx, observation, shifting=True, symmetric=False, monotonic=True, thresh=5)\n",
+    "new_source = scarlet.ExtendedSource(model_frame_, yx, observation, shifting=True)\n",
     "sources_.append(new_source)\n",
-    "yx = (43., 12.)\n",
-    "new_source = scarlet.ExtendedSource(model_frame_, yx, observation, shifting=True, symmetric=False, monotonic=True, thresh=5)\n",
+    "yx = (42., 9.)\n",
+    "new_source = scarlet.ExtendedSource(model_frame_, yx, observation, shifting=True)\n",
     "sources_.append(new_source)\n",
     "\n",
     "# generate a new Blend instance\n",
     "blend_ = scarlet.Blend(sources_, observation)\n",
     "# tighten relative change in likelihood for convergence\n",
-    "blend_.fit(200, e_rel=1e-5)\n",
+    "blend_.fit(200, e_rel=1e-4)\n",
     "\n",
     "# show convergence of logL\n",
     "print(\"scarlet ran for {0} iterations to logL = {1}\".format(len(blend_.loss), -blend_.loss[-1]))\n",
@@ -445,15 +443,8 @@
    "outputs": [],
    "source": [
     "# minimal regression testing (hidden in sphinx)\n",
-    "np.testing.assert_almost_equal(-blend_.loss[-1], 31399.978714738645, decimal=2)"
+    "np.testing.assert_almost_equal(-blend_.loss[-1], 31262.29884949654, decimal=2)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/1-concepts.ipynb
+++ b/docs/1-concepts.ipynb
@@ -307,15 +307,25 @@
     "In detail, this assumption is incorrect e.g. for spiral galaxies, especially tightly wound ones.\n",
     "But we can build good representations of even complex galaxies as multiple stellar populations, each with a single SED and monotonically decreasing from its peak.\n",
     "\n",
-    "In *scarlet* monotonicity is implemented as a projection that is *not* a true proximal operator. It is possible to write monotonicity as a true proximal operator, but the implementation is far too slow for practical purposes. Instead, the morphology is projected into a space that has *a* monotonic solution, just not the closest one. We implemented two possible monotonic solutions in `MonotonicityConstraint`. If `use_nearest=True`, then only a single reference pixel is used: the nearest one in the direction to the peak.\n",
-    "With `use_nearest=False` a weighted average of all pixels closer to the peak than the current pixel is used to allow for a smoother monotonic solution.\n",
+    "We implemented three possible monotonic solutions in `MonotonicityConstraint`. Each of them restrict the intensity of the active pixel $i$ (blue) to at most the average of the pixel intensity of its direct neighbors in the direction of the source center (ochre):\n",
+    "\n",
+    "$$\n",
+    "x_i\\leq\\frac{1}{N_i}\\sum_j^{N_i} w_j x_j\n",
+    "$$\n",
     "\n",
     "| ![](images/nearest_ref.png) | ![](images/weighted_ref.png) |\n",
     "|:---------------------------:|:----------------------------:|\n",
     "| Nearest Neighbor            | Weighted Reference           |\n",
     "\n",
+    "* `neighbor_weight='nearest'`: Only the neighbor that is closest to the center  defines the reference. This mode is the most flexible one but prone to creating radial \"spikes\".\n",
+    "* `neighbor_weight='angle'`: All three neighbor pixels that are closer to the peak are combined to compute the reference intensity. The weights of the neighbor $w_j = \\cos(\\alpha_i - \\alpha_j)$, where $\\alpha_i$ and $\\alpha_j$ are the angles from the active and the neighbor pixel to the center, respectively. This option is a softened version of the nearest-neighbor weight but still prefers strong radial monotonicity and thus similarly prone to radial spikes.\n",
+    "* `neighbor_weight='flat'`: All three neighbor pixels that are closer to the peak are combined with flat weights to compute the reference intensity. This option is the most restrictive and allows for the greatest degree of azimuthal smoothing.\n",
     "\n",
-    "The monotonicity mapping hinges on a properly centered source, but in contrast to symmetry the center has to be localized only within one pixel."
+    "The monotonicity mapping hinges on a properly centered source, but in contrast to symmetry the center has to be localized only within one pixel.\n",
+    "\n",
+    "#### Implementation Note\n",
+    "\n",
+    "`MonotonicityConstraint` is implemented as a projection that is *not* a true proximal operator. It is possible to write monotonicity as a true proximal operator, but the implementation is far too slow for practical purposes. Instead, the morphology is projected into a space that has *a* monotonic solution, just not necessarily the closest one in the L2 sense."
    ]
   },
   {

--- a/scarlet/constraint.py
+++ b/scarlet/constraint.py
@@ -181,26 +181,28 @@ class MonotonicityConstraint(Constraint):
     for a description of the other parameters.
     """
 
-    def __init__(self, use_nearest=False, thresh=0):
-        self.use_nearest = use_nearest
-        self.thresh = thresh
+    def __init__(self, neighbor_weight="flat", min_gradient=0):
+        self.neighbor_weight = neighbor_weight
+        self.min_gradient = min_gradient
 
     def __call__(self, morph, step):
         shape = morph.shape
         center = (shape[0] // 2, shape[1] // 2)
 
         # get prox from the cache
-        prox_name = "operator.prox_strict_monotonic"
-        key = (shape, center, self.use_nearest, self.thresh)
+        prox_name = "operator.prox_weighted_monotonic"
+        key = (shape, center, self.neighbor_weight, self.min_gradient)
         # The creation of this operator is expensive,
         # so load it from memory if possible.
         try:
             prox = Cache.check(prox_name, key)
         except KeyError:
-            prox = operator.prox_strict_monotonic(
-                shape, use_nearest=self.use_nearest, thresh=self.thresh, center=center
+            prox = operator.prox_weighted_monotonic(
+                shape,
+                neighbor_weight=self.neighbor_weight,
+                min_gradient=self.min_gradient,
+                center=center,
             )
-
             Cache.set(prox_name, key, prox)
 
         # apply the prox

--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -9,26 +9,6 @@ from . import interpolation
 from .cache import Cache
 
 
-def _prox_strict_monotonic(X, step, ref_idx, dist_idx, thresh=0):
-    """Force an intensity profile to be monotonic based on nearest neighbor
-    """
-    from . import operators_pybind11
-
-    operators_pybind11.prox_monotonic(X.reshape(-1), ref_idx, dist_idx, thresh)
-    return X
-
-
-def _prox_weighted_monotonic(X, step, weights, didx, offsets, thresh=0):
-    """Force an intensity profile to be monotonic based on weighting neighbors
-    """
-    from . import operators_pybind11
-
-    operators_pybind11.prox_weighted_monotonic(
-        X.reshape(-1), weights, offsets, didx, thresh
-    )
-    return X
-
-
 def sort_by_radius(shape, center=None):
     """Sort indices distance from the center
 
@@ -70,16 +50,26 @@ def sort_by_radius(shape, center=None):
     return didx
 
 
-def prox_strict_monotonic(shape, use_nearest=False, thresh=0, center=None):
+def _prox_weighted_monotonic(X, step, weights, didx, offsets, min_gradient=0):
+    """Force an intensity profile to be monotonic based on weighting neighbors
+    """
+    from . import operators_pybind11
+
+    operators_pybind11.prox_weighted_monotonic(
+        X.reshape(-1), weights, offsets, didx, min_gradient
+    )
+    return X
+
+
+def prox_weighted_monotonic(shape, neighbor_weight="flat", min_gradient=0, center=None):
     """Build the prox_monotonic operator
 
     Parameters
     ----------
-    use_nearest: `bool`
-        Whether to use the nearest pixel to the center for comparison
-        (`use_nearest=True`) or use a weighted combination of all
-        neighbors closer to the central pixel (`use_nearest=False`).
-    thresh: `float`
+    neighbor_weight: ['flat', 'angle', 'nearest']
+        Which weighting scheme to average all neighbor pixels towards `center`
+        as reference for the monotonicty test.
+    min_gradient: `float`
         Forced gradient. A `thresh` of zero will allow a pixel to be the
         same value as its reference pixels, while a `thresh` of one
         will force the pixel to zero.
@@ -93,36 +83,18 @@ def prox_strict_monotonic(shape, use_nearest=False, thresh=0, center=None):
     """
     height, width = shape
     didx = sort_by_radius(shape, center)
-
-    if use_nearest:
-        from scipy import sparse
-
-        if thresh != 0:
-            # thresh and nearest neighbors are not compatible, since this thresholds the
-            # central pixel and eventually sets the entire array to zero
-            raise ValueError(
-                "Thresholding does not work with nearest neighbor monotonicity"
-            )
-        monotonicOp = getRadialMonotonicOp(shape, useNearest=True)
-        x_idx, ref_idx = sparse.find(monotonicOp.L == 1)[:2]
-        ref_idx = ref_idx[np.argsort(x_idx)]
-        result = partial(
-            _prox_strict_monotonic,
-            ref_idx=ref_idx.tolist(),
-            dist_idx=didx.tolist(),
-            thresh=thresh,
-        )
-    else:
-        coords = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
-        offsets = np.array([width * y + x for y, x in coords])
-        weights = getRadialMonotonicWeights(shape, useNearest=False, center=center)
-        result = partial(
-            _prox_weighted_monotonic,
-            weights=weights,
-            didx=didx[1:],
-            offsets=offsets,
-            thresh=thresh,
-        )
+    coords = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
+    offsets = np.array([width * y + x for y, x in coords])
+    weights = getRadialMonotonicWeights(
+        shape, neighbor_weight=neighbor_weight, center=center
+    )
+    result = partial(
+        _prox_weighted_monotonic,
+        weights=weights,
+        didx=didx[1:],
+        offsets=offsets,
+        min_gradient=min_gradient,
+    )
     return result
 
 
@@ -261,14 +233,14 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
     # Compute shift operator
     shifter_y, shifter_x = interpolation.mk_shifter(fft_shape)
 
-    #Apply shift in Fourier
+    # Apply shift in Fourier
     result_fft = X_fft * np.exp(shifter_y[:, np.newaxis] * (-dy))
     result_fft *= np.exp(shifter_x[np.newaxis, :] * (-dx))
 
     # symmetrize
     result_fft = result_fft.real
 
-    #Unshift
+    # Unshift
     result_fft = result_fft * np.exp(shifter_y[:, np.newaxis] * dy)
     result_fft = result_fft * np.exp(shifter_x[np.newaxis, :] * dx)
 
@@ -534,19 +506,20 @@ def diagonalsToSparse(diagonals, shape, dtype=np.float64):
     return diagonalArr
 
 
-def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None):
+def getRadialMonotonicWeights(shape, neighbor_weight="flat", center=None):
     """Create the weights used for the Radial Monotonicity Operator
     This version of the radial monotonicity operator selects all of the pixels closer to the peak
     for each pixel and weights their flux based on their alignment with a vector from the pixel
     to the peak. In order to quickly create this using sparse matrices, its construction is a bit opaque.
     """
+    assert neighbor_weight in ["flat", "angle", "nearest"]
+
     if center is None:
         center = ((shape[0] - 1) // 2, (shape[1] - 1) // 2)
     name = "RadialMonotonicWeights"
 
-    key = tuple(shape) + tuple(center) + (useNearest, minGradient)
+    key = tuple(shape) + tuple(center) + (neighbor_weight,)
     try:
-
         cosNorm = Cache.check(name, key)
     except KeyError:
 
@@ -574,7 +547,7 @@ def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None
         angles = np.arctan2(-Y, -tX)
         angles[inf & (Y != 0)] = 0.5 * np.pi * np.sign(angles[inf & (Y != 0)])
 
-        # Calcualte the angle between each pixel and it's neighbors
+        # Calculate the angle between each pixel and its neighbors
         xArr, m = diagonalizeArray(X)
         yArr, m = diagonalizeArray(Y)
         dx = (xArr.T - X.flatten()[:, None]).T
@@ -597,17 +570,20 @@ def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None
         cosWeight[invalidPix] = 0
         cosWeight[mask] = 0
 
-        if useNearest:
+        if neighbor_weight == "nearest":
             # Only use a single pixel most in line with peak
             cosNorm = np.zeros_like(cosWeight)
             columnIndices = np.arange(cosWeight.shape[1])
             maxIndices = np.argmax(cosWeight, axis=0)
             indices = maxIndices * cosNorm.shape[1] + columnIndices
             indices = np.unravel_index(indices, cosNorm.shape)
-            cosNorm[indices] = minGradient
+            cosNorm[indices] = 1
             # Remove the reference for the peak pixel
             cosNorm[:, px + py * shape[1]] = 0
         else:
+            if neighbor_weight == "flat":
+                cosWeight[cosWeight != 0] = 1
+
             # Normalize the cos weights for each pixel
             normalize = np.sum(cosWeight, axis=0)
             normalize[normalize == 0] = 1
@@ -617,39 +593,3 @@ def getRadialMonotonicWeights(shape, useNearest=True, minGradient=1, center=None
         Cache.set(name, key, cosNorm)
 
     return cosNorm
-
-
-def getRadialMonotonicOp(shape, useNearest=True, minGradient=1, subtract=True):
-    """Create an operator to constrain radial monotonicity
-    This version of the radial monotonicity operator selects all of the pixels closer to the peak
-    for each pixel and weights their flux based on their alignment with a vector from the pixel
-    to the peak. In order to quickly create this using sparse matrices, its construction is a bit opaque.
-    """
-    import scipy.sparse
-
-    name = "RadialMonotonic"
-    key = tuple(shape) + (useNearest, minGradient, subtract)
-    try:
-        monotonic = Cache.check(name, key)
-    except KeyError:
-
-        cosNorm = getRadialMonotonicWeights(shape, useNearest=useNearest, minGradient=1)
-        cosArr = diagonalsToSparse(cosNorm, shape)
-
-        # The identity with the peak pixel removed represents the reference pixels
-        # Center on the center pixel
-        px = int(shape[1] / 2)
-        py = int(shape[0] / 2)
-        # Calculate the distance between each pixel and the peak
-        size = shape[0] * shape[1]
-        diagonal = np.ones(size)
-        diagonal[px + py * shape[1]] = -1
-        if subtract:
-            monotonic = cosArr - scipy.sparse.diags(diagonal, offsets=0)
-        else:
-            monotonic = cosArr
-        monotonic = MatrixAdapter(monotonic.tocoo(), axis=1)
-        monotonic.spectral_norm
-        Cache.set(name, key, monotonic)
-
-    return monotonic

--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -513,17 +513,15 @@ def getRadialMonotonicWeights(shape, neighbor_weight="flat", center=None):
     """
     assert neighbor_weight in ["flat", "angle", "nearest"]
 
+    # Center on the center pixel
     if center is None:
         center = ((shape[0] - 1) // 2, (shape[1] - 1) // 2)
-
-    # Center on the center pixel
     py, px = int(center[0]), int(center[1])
+
     # Calculate the distance between each pixel and the peak
-    x = np.arange(shape[1])
-    y = np.arange(shape[0])
+    x = np.arange(shape[1]) - px
+    y = np.arange(shape[0]) - py
     X, Y = np.meshgrid(x, y)
-    X = X - px
-    Y = Y - py
     distance = np.sqrt(X ** 2 + Y ** 2)
 
     # Find each pixels neighbors further from the peak and mark them as invalid

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -461,7 +461,7 @@ class ExtendedSource(FactorizedComponent):
 
         # backwards compatibility: monotonic was boolean
         if monotonic is True:
-            neighbor_weight = "angle"
+            monotonic = "angle"
         elif monotonic is False:
             monotonic = None
         if monotonic is not None:
@@ -574,7 +574,7 @@ class MultiComponentSource(ComponentTree):
 
         # backwards compatibility: monotonic was boolean
         if monotonic is True:
-            neighbor_weight = "angle"
+            monotonic = "angle"
         elif monotonic is False:
             monotonic = None
         if monotonic is not None:

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -5,7 +5,6 @@ import scarlet
 
 
 class TestUpdate(object):
-
     def test_positivity(self):
         X = np.random.rand(100) - 0.5
         step = 0
@@ -19,12 +18,12 @@ class TestUpdate(object):
         step = 0
 
         X_ = X.copy()
-        constraint = scarlet.NormalizationConstraint(type='sum')
+        constraint = scarlet.NormalizationConstraint(type="sum")
         X_ = constraint(X_, step)
         assert_almost_equal(X_, X / X.sum())
 
         X_ = X.copy()
-        constraint = scarlet.NormalizationConstraint(type='max')
+        constraint = scarlet.NormalizationConstraint(type="max")
         X_ = constraint(X_, step)
         assert_almost_equal(X_, X / X.max())
 
@@ -34,14 +33,14 @@ class TestUpdate(object):
         thresh = 0.25
 
         X_ = X.copy()
-        constraint = scarlet.L0Constraint(thresh=thresh, type='relative')
+        constraint = scarlet.L0Constraint(thresh=thresh, type="relative")
         X_ = constraint(X_, step)
-        mask = np.abs(X) < thresh*step
+        mask = np.abs(X) < thresh * step
         assert all(np.abs(X_[mask]) == 0)
         assert_array_equal(X_[~mask], X[~mask])
 
         X_ = X.copy()
-        constraint = scarlet.L0Constraint(thresh=thresh, type='absolute')
+        constraint = scarlet.L0Constraint(thresh=thresh, type="absolute")
         X_ = constraint(X_, step)
         mask = np.abs(X) < thresh
         assert all(np.abs(X_[mask]) == 0)
@@ -53,15 +52,15 @@ class TestUpdate(object):
         thresh = 0.25
 
         X_ = X.copy()
-        constraint = scarlet.L1Constraint(thresh=thresh, type='relative')
+        constraint = scarlet.L1Constraint(thresh=thresh, type="relative")
         X_ = constraint(X_, step)
-        thresh_ = thresh*step
+        thresh_ = thresh * step
         mask = np.abs(X) < thresh_
         assert all(np.abs(X_[mask]) == 0)
         assert_array_equal(np.abs(X_[~mask]), np.abs(np.abs(X[~mask]) - thresh_))
 
         X_ = X.copy()
-        constraint = scarlet.L1Constraint(thresh=thresh, type='absolute')
+        constraint = scarlet.L1Constraint(thresh=thresh, type="absolute")
         X_ = constraint(X_, step)
         mask = np.abs(X) < thresh
         assert all(np.abs(X_[mask]) == 0)
@@ -70,12 +69,13 @@ class TestUpdate(object):
     def test_threshold(self):
         # Use a random seed in the test to prevent race conditions
         np.random.seed(0)
-        noise = np.random.rand(21, 21)*2  # noise background to eliminate
+        noise = np.random.rand(21, 21) * 2  # noise background to eliminate
         signal = np.zeros(noise.shape)
         func = scarlet.psf.gaussian
-        signal[7:14, 7:14] = 10 * scarlet.PSF(func, shape=(None, 21, 21)).image[0, 7:14, 7:14]
+        signal[7:14, 7:14] = (
+            10 * scarlet.PSF(func, shape=(None, 21, 21)).image[0, 7:14, 7:14]
+        )
         X = signal + noise
-
 
         step = 0
         constraint = scarlet.ThresholdConstraint()
@@ -89,42 +89,54 @@ class TestUpdate(object):
 
     def test_monotonic(self):
         shape = (5, 5)
-        X = np.arange(shape[0]*shape[1], dtype=float).reshape(*shape)
+        X = np.arange(shape[0] * shape[1], dtype=float).reshape(*shape)
 
         step = 0
         X_ = X.copy()
-        constraint = scarlet.MonotonicityConstraint(use_nearest=True, thresh=0)
+        constraint = scarlet.MonotonicityConstraint(
+            neighbor_weight="nearest", min_gradient=0
+        )
         X_ = constraint(X_, step)
-        new_X = [[0.0, 1.0, 2.0, 3.0, 4.0],
-                 [5.0, 6.0, 7.0, 8.0, 9.0],
-                 [10.0, 11.0, 12.0, 12.0, 12.0],
-                 [11.0, 12.0, 12.0, 12.0, 12.0],
-                 [12.0, 12.0, 12.0, 12.0, 12.0]]
+        new_X = [
+            [0.0, 1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0, 12.0, 12.0],
+            [11.0, 12.0, 12.0, 12.0, 12.0],
+            [12.0, 12.0, 12.0, 12.0, 12.0],
+        ]
         assert_array_equal(X_, new_X)
 
         X_ = X.copy()
-        constraint = scarlet.MonotonicityConstraint(use_nearest=False, thresh=0)
+        constraint = scarlet.MonotonicityConstraint(
+            neighbor_weight="angle", min_gradient=0
+        )
         X_ = constraint(X_, step)
-        new_X = [[0.000000000, 1.000000000, 2.000000000, 3.000000000, 4.000000000],
-                 [5.000000000, 6.000000000, 7.000000000, 8.000000000, 9.000000000],
-                 [9.742640687, 11.000000000, 12.000000000, 12.000000000, 10.828427125],
-                 [11.030627697, 11.707106781, 12.000000000, 12.000000000, 11.771236166],
-                 [11.556349186, 11.868867239, 11.914213562, 11.983249156, 11.928090416]]
+        new_X = [
+            [0.000000000, 1.000000000, 2.000000000, 3.000000000, 4.000000000],
+            [5.000000000, 6.000000000, 7.000000000, 8.000000000, 9.000000000],
+            [9.742640687, 11.000000000, 12.000000000, 12.000000000, 10.828427125],
+            [11.030627697, 11.707106781, 12.000000000, 12.000000000, 11.771236166],
+            [11.556349186, 11.868867239, 11.914213562, 11.983249156, 11.928090416],
+        ]
         assert_almost_equal(X_, new_X)
 
         X_ = X.copy()
-        constraint = scarlet.MonotonicityConstraint(use_nearest=False, thresh=0.25)
+        constraint = scarlet.MonotonicityConstraint(
+            neighbor_weight="angle", min_gradient=0.25
+        )
         X_ = constraint(X_, step)
-        new_X = [[0.000000000, 1.000000000, 2.000000000, 3.000000000, 4.000000000],
-                 [5.000000000, 6.000000000, 7.000000000, 7.242640687, 5.806841831],
-                 [5.801461031, 9.000000000, 12.000000000, 9.000000000, 6.074431804],
-                 [5.895545844, 7.681980515, 9.000000000, 7.681980515, 5.935521488],
-                 [4.988519641, 5.949655012, 6.170941546, 5.949655012, 4.997301087]]
+        new_X = [
+            [0.000000000, 1.000000000, 2.000000000, 3.000000000, 4.000000000],
+            [5.000000000, 6.000000000, 7.000000000, 7.242640687, 5.806841831],
+            [5.801461031, 9.000000000, 12.000000000, 9.000000000, 6.074431804],
+            [5.895545844, 7.681980515, 9.000000000, 7.681980515, 5.935521488],
+            [4.988519641, 5.949655012, 6.170941546, 5.949655012, 4.997301087],
+        ]
         assert_almost_equal(X_, new_X)
 
     def test_symmetry(self):
-        shape = (5,5)
-        X = np.arange(shape[0]*shape[1], dtype=float).reshape(*shape)
+        shape = (5, 5)
+        X = np.arange(shape[0] * shape[1], dtype=float).reshape(*shape)
 
         # symmetry
         step = 0
@@ -138,24 +150,26 @@ class TestUpdate(object):
         X_ = X.copy()
         constraint = scarlet.SymmetryConstraint(strength=0.5)
         X_ = constraint(X_, step)
-        new_X = [[6.0, 6.5, 7.0, 7.5, 8.0],
-                  [8.5, 9.0, 9.5, 10.0, 10.5],
-                  [11.0, 11.5, 12.0, 12.5, 13.0],
-                  [13.5, 14.0, 14.5, 15.0, 15.5],
-                  [16.0, 16.5, 17.0, 17.5, 18.0]]
+        new_X = [
+            [6.0, 6.5, 7.0, 7.5, 8.0],
+            [8.5, 9.0, 9.5, 10.0, 10.5],
+            [11.0, 11.5, 12.0, 12.5, 13.0],
+            [13.5, 14.0, 14.5, 15.0, 15.5],
+            [16.0, 16.5, 17.0, 17.5, 18.0],
+        ]
         assert_almost_equal(X_, new_X)
 
     def test_center_on(self):
-        shape = (5,5)
+        shape = (5, 5)
         X = np.zeros(shape)
 
         constraint = scarlet.CenterOnConstraint()
         step = 0
         X = constraint(X, step)
-        assert X[2,2] > 0
+        assert X[2, 2] > 0
 
     def test_all_on(self):
-        shape = (5,5)
+        shape = (5, 5)
         X = np.zeros(shape)
 
         constraint = scarlet.AllOnConstraint()


### PR DESCRIPTION
* Implements flat monotonicity weighting over all three neighbor pixels, which reduces radial streaking
* Allows the user the set the monotonicity weighting scheme for each source model.

Plus some spring cleaning ... I removed the special code for nearest-neighbor monotonicity, which we haven't used anymore for more than 1 year.