### PR TITLE
relative_step bug fixed

### DIFF
--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -72,7 +72,6 @@ class Blend(ComponentTree):
         # good defaults for adaprox
         scheme = alg_kwargs.pop("scheme", "amsgrad")
         prox_max_iter = alg_kwargs.pop("prox_max_iter", 10)
-        eps = alg_kwargs.pop("eps", 1e-8)
         callback = partial(
             self._callback, e_rel=e_rel, callback=alg_kwargs.pop("callback", None)
         )

--- a/scarlet/parameter.py
+++ b/scarlet/parameter.py
@@ -106,5 +106,5 @@ ArrayBox.register(Parameter)
 VSpace.register(Parameter, vspace_maker=VSpace.mappings[np.ndarray])
 
 
-def relative_step(X, it, factor=0.1):
-    return factor * X.mean(axis=0)
+def relative_step(X, it, factor=0.1, axis=None):
+    return factor * X.mean(axis=axis)

--- a/scarlet/prior.py
+++ b/scarlet/prior.py
@@ -1,6 +1,4 @@
 from abc import ABC, abstractmethod
-import numpy as np
-
 
 class Prior(ABC):
     """Prior base class


### PR DESCRIPTION
This PR fixes a bug in the relative_step function where the step was computed by averaging over one axis of a parameter. When the parameter is a morphology, this caused vertical artifacts to appear during the optimisation process.

I also used this PR to remove a few variables that were not used.