### PR TITLE
Invert the load order of the merged branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - git clone https://${TESTING_REPO}
   - cd scarlet_extensions
   - # Checkout the scarlet_extensions branch, if one is available (otherwise it will use master)
-  - git rev-parse --verify origin/${TRAVIS_BRANCH} && git checkout ${TRAVIS_BRANCH}
+  - git rev-parse -q --verify origin/${TRAVIS_BRANCH} && git checkout ${TRAVIS_BRANCH}
   - git branch
   - python setup.py develop
   # Run the script on all three datasets

--- a/docs/_static/aws_scarlet.js
+++ b/docs/_static/aws_scarlet.js
@@ -76,7 +76,7 @@ function get_merged_branches(callback){
         } else {
             // Initialize the dropdown buttons
             let branch_data = data["Items"];
-            branch_data.sort(function(a,b){
+            branch_data.sort(function(b,a){
                 if(a["merge_order"] < b["merge_order"]){
                     return -1;
                 } else if(a["merge_order"] > b["merge_order"]){


### PR DESCRIPTION
One of the datasets needed to make the regression testing docs work is the list of merged branches, in order. This is stored in a DynamoDB table with the name of the branch and the index order acting as the unique keys for the table. The problem is by default git returns the branches in order with the newest first, which causes problems when the table updates on a new merge to master.

This PR fixes the problem by inverting the order of the merged branches on write (in scarlet_extensions) and requires a simple change here to invert the order again so that we correctly use the "last N commits" in the correct order.