### PR TITLE
Use python 3.8 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 3.6
+  - 3.8
 notifications:
   email: false
 env:

--- a/scarlet/psf.py
+++ b/scarlet/psf.py
@@ -83,7 +83,8 @@ class FunctionPSF(PSF):
         self._d = self.bbox.D - 2
 
     def expand_dims(self, model):
-        return np.expand_dims(model, axis=np.arange(self._d))
+        return np.expand_dims(model, axis=tuple(range(self._d)))
+
 
 
 class GaussianPSF(FunctionPSF):


### PR DESCRIPTION
Rubin Observatory is having trouble with scarlet on python 3.8. This is a test to see if all of the tests pass. If not, this branch will contain changes to allow scarlet to pass on scarlet 3.8.