### PR TITLE
Propagate downgrade and fallback parameters

### DIFF
--- a/scarlet/initialization.py
+++ b/scarlet/initialization.py
@@ -980,6 +980,8 @@ def initSource(
                 maxComponents,
                 edgeDistance,
                 shifting=True,
+                downgrade=downgrade,
+                fallback=fallback,
             )
         source.isEdge = True
     else:


### PR DESCRIPTION
This PR fixes the bug seen in DC2 data where a small edge source triggers a re-initialization but the `downgrade` and `fallback` parameters are not set, resulting in small, faint sources being deblended as point sources.