### PR TITLE
fix np.float deprecation

### DIFF
--- a/scarlet/frame.py
+++ b/scarlet/frame.py
@@ -89,7 +89,7 @@ class Frame:
         sky_coord: tuple, array
             Coordinates on the sky
         """
-        sky = np.array(sky_coord, dtype=np.float).reshape(-1, 2)
+        sky = np.array(sky_coord, dtype=np.float64).reshape(-1, 2)
 
         if self.wcs is not None:
             wcs_ = self.wcs.celestial  # only use celestial portion
@@ -111,7 +111,7 @@ class Frame:
         pixel: tuple, array
             Coordinates in the pixel space
         """
-        pix = np.array(pixel, dtype=np.float).reshape(-1, 2)
+        pix = np.array(pixel, dtype=np.float64).reshape(-1, 2)
 
         if self.wcs is not None:
             wcs_ = self.wcs.celestial  # only use celestial portion
@@ -142,7 +142,7 @@ class Frame:
             coordinates at the location of `coord` in the target frame
         """
         if pixel is None:
-            y, x = np.indices(self.shape[-2:], dtype=np.float)
+            y, x = np.indices(self.shape[-2:], dtype=np.float64)
             pixel = np.stack((y.flatten(), x.flatten()), axis=1)
 
         ra_dec = self.get_sky_coord(pixel)

--- a/scarlet/measure.py
+++ b/scarlet/measure.py
@@ -132,7 +132,7 @@ def moments(component, N=2, centroid=None, weight=None):
     if centroid is None:
         centroid = np.array(model.shape) // 2
 
-    grid_x, grid_y = np.indices(model.shape[-2:], dtype=np.float)
+    grid_x, grid_y = np.indices(model.shape[-2:], dtype=np.float64)
     if len(model.shape) == 3:
         grid_y = grid_y[None, :, :]
         grid_x = grid_x[None, :, :]


### PR DESCRIPTION
In numpy 1.20.0 an exception is raised when using `np.int`, `np.float`, etc. since numpy no longer aliases those to `int` and `float` respectively. I made a hotfix in the lsst version of scarlet earlier this week to prevent breaking the entire stack, but we should fix this in master as well.