### PR TITLE
init with size of at least the PSF

### DIFF
--- a/scarlet/initialization.py
+++ b/scarlet/initialization.py
@@ -328,6 +328,8 @@ def init_all_sources(
     min_components=1,
     min_snr=50,
     shifting=False,
+    resizing=True,
+    boxsize=None,
     fallback=True,
     silent=False,
     set_spectra=True,
@@ -377,6 +379,8 @@ def init_all_sources(
                 min_components=min_components,
                 min_snr=min_snr,
                 shifting=shifting,
+                resizing=resizing,
+                boxsize=boxsize,
                 fallback=fallback,
             )
             sources.append(source)
@@ -403,6 +407,8 @@ def init_source(
     min_components=1,
     min_snr=50,
     shifting=False,
+    resizing=True,
+    boxsize=None,
     fallback=True,
 ):
     """Initialize a Source
@@ -451,6 +457,10 @@ def init_source(
         Whether or not to fit the position of a source.
         This is an expensive operation and is typically only used when
         a source is on the edge of the detector.
+    resizing : bool
+        Whether or not to change the size of the source box.
+    boxsize: int or None
+        Spatial size of the source box
     fallback : bool
         Whether to reduce the number of components
         if the model cannot be initialized with `max_components`.
@@ -466,7 +476,6 @@ def init_source(
     if not hasattr(observations, "__iter__"):
         observations = (observations,)
 
-    source_shifting = shifting
     if fallback:
         _, psf_snr = get_psf_spectrum(center, observations, compute_snr=True)
         max_components = np.min(
@@ -484,12 +493,20 @@ def init_source(
                     center,
                     observations,
                     thresh=thresh,
-                    shifting=source_shifting,
+                    shifting=shifting,
+                    resizing=resizing,
+                    boxsize=boxsize,
                     K=max_components,
                 )
             else:
                 source = ExtendedSource(
-                    frame, center, observations, shifting=source_shifting, compact=True
+                    frame,
+                    center,
+                    observations,
+                    shifting=shifting,
+                    resizing=resizing,
+                    boxsize=boxsize,
+                    compact=True,
                 )
 
             # test if parameters are fine, otherwise throw ArithmeticError

--- a/scarlet/initialization.py
+++ b/scarlet/initialization.py
@@ -220,7 +220,7 @@ def get_minimal_boxsize(size, min_size=21, increment=10):
     return boxsize
 
 
-def trim_morphology(center_index, morph, bg_thresh=0):
+def trim_morphology(center_index, morph, bg_thresh=0, boxsize=None):
     # trim morph to pixels above threshold
     mask = morph > bg_thresh
     morph[~mask] = 0
@@ -241,7 +241,9 @@ def trim_morphology(center_index, morph, bg_thresh=0):
         size = 0
 
     # define new box and cut morphology accordingly
-    boxsize = get_minimal_boxsize(size)
+    if boxsize is None:
+        boxsize = get_minimal_boxsize(size)
+
     bottom = center_index[0] - boxsize // 2
     top = center_index[0] + boxsize // 2 + 1
     left = center_index[1] - boxsize // 2
@@ -323,6 +325,7 @@ def init_all_sources(
     observations,
     thresh=1,
     max_components=1,
+    min_components=1,
     min_snr=50,
     shifting=False,
     fallback=True,
@@ -371,6 +374,7 @@ def init_all_sources(
                 observations,
                 thresh=thresh,
                 max_components=max_components,
+                min_components=min_components,
                 min_snr=min_snr,
                 shifting=shifting,
                 fallback=fallback,
@@ -396,6 +400,7 @@ def init_source(
     observations,
     thresh=1,
     max_components=1,
+    min_components=1,
     min_snr=50,
     shifting=False,
     fallback=True,
@@ -437,6 +442,9 @@ def init_source(
         will continue to subtract one from the number of components
         until it reaches zero (which fits a `CompactExtendedSource`).
         If a point source cannot be fit then the source is skipped.
+    min_components : int
+        The minimum number of components in a source.
+        Only relevent for `fallback=True`.
     min_snr: float
         Mininmum SNR per component to accept the source.
     shifting : bool
@@ -462,7 +470,10 @@ def init_source(
     if fallback:
         _, psf_snr = get_psf_spectrum(center, observations, compute_snr=True)
         max_components = np.min(
-            [max_components, np.max([0, np.floor(psf_snr / min_snr).astype("int")])]
+            [
+                max_components,
+                np.max([min_components, np.floor(psf_snr / min_snr).astype("int")]),
+            ]
         )
 
     while max_components >= 0:

--- a/scarlet/morphology.py
+++ b/scarlet/morphology.py
@@ -63,6 +63,8 @@ class ImageMorphology(Morphology):
         2D bounding box for focation of the image in `frame`
     shift: None or `~scarlet.Parameter`
         2D shift parameter (in units of image pixels)
+    resize: bool
+        Whether to resize the box dynamically
     """
 
     def __init__(self, frame, image, bbox=None, shift=None, resize=True):
@@ -291,6 +293,7 @@ class ExtendedSourceMorphology(ImageMorphology):
         symmetric=False,
         min_grad=0,
         shifting=False,
+        resize=True,
     ):
         """Non-parametric image morphology designed for galaxies as extended sources.
 
@@ -312,6 +315,8 @@ class ExtendedSourceMorphology(ImageMorphology):
             Minimal radial decline for monotonicity (in units of reference pixel value)
         shifting: `bool`
             Whether or not a subpixel shift is added as optimization parameter
+        resize: bool
+            Whether to resize the box dynamically
         """
 
         constraints = []
@@ -349,7 +354,7 @@ class ExtendedSourceMorphology(ImageMorphology):
             shift = None
         self.shift = shift
 
-        super().__init__(frame, image, bbox=bbox, shift=shift)
+        super().__init__(frame, image, bbox=bbox, shift=shift, resize=resize)
 
     @property
     def center(self):

--- a/scarlet/morphology.py
+++ b/scarlet/morphology.py
@@ -67,7 +67,9 @@ class ImageMorphology(Morphology):
         Whether to resize the box dynamically
     """
 
-    def __init__(self, frame, image, bbox=None, shift=None, resizing=True):
+    def __init__(
+        self, frame, image, bbox=None, shifting=False, shift=None, resizing=True
+    ):
         if isinstance(image, Parameter):
             assert image.name == "image"
         else:
@@ -83,15 +85,17 @@ class ImageMorphology(Morphology):
             assert bbox.shape == image.shape
 
         self.resizing = resizing
-        self.shifting = shift is not None
+        self.shifting = shifting
+
         # create the shift parameter to allow for dynamic resizing
         if shift is None:
-            shift = Parameter(np.zeros(2), name="shift", step=1e-2, fixed=self.shift)
-        assert shift.shape == (2,)
-        if isinstance(shift, Parameter):
-            assert shift.name == "shift"
+            shift = Parameter(np.zeros(2), name="shift", step=1e-2, fixed=self.shifting)
         else:
-            shift = Parameter(shift, name="shift", step=1e-2)
+            assert shift.shape == (2,)
+            if isinstance(shift, Parameter):
+                assert shift.name == "shift"
+            else:
+                shift = Parameter(shift, name="shift", step=1e-2)
 
         parameters = (image, shift)
         super().__init__(frame, *parameters, bbox=bbox)
@@ -354,7 +358,9 @@ class ExtendedSourceMorphology(ImageMorphology):
             shift = None
         self.shift = shift
 
-        super().__init__(frame, image, bbox=bbox, shift=shift, resizing=resizing)
+        super().__init__(
+            frame, image, bbox=bbox, shifting=shifting, shift=shift, resizing=resizing
+        )
 
     @property
     def center(self):

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -136,7 +136,13 @@ class PointSource(FactorizedComponent):
 
 class CompactExtendedSource(FactorizedComponent):
     def __init__(
-        self, model_frame, sky_coord, observations, shifting=False, boxsize=None
+        self,
+        model_frame,
+        sky_coord,
+        observations,
+        shifting=False,
+        resizing=True,
+        boxsize=None,
     ):
         """Compact extended source model
 
@@ -156,6 +162,8 @@ class CompactExtendedSource(FactorizedComponent):
             Observation(s) to initialize this source.
         shifting: `bool`
             Whether or not a subpixel shift is added as optimization parameter
+        resizing : bool
+            Whether or not to change the size of the source box.
         boxsize: int or None
             Spatial size of the source box
         """
@@ -175,6 +183,7 @@ class CompactExtendedSource(FactorizedComponent):
             symmetric=False,
             min_grad=0,
             shifting=shifting,
+            resizing=resizing,
         )
 
         # get spectrum from peak pixel, correct for PSF
@@ -252,6 +261,7 @@ class SingleExtendedSource(FactorizedComponent):
         observations,
         thresh=1.0,
         shifting=False,
+        resizing=True,
         boxsize=None,
     ):
         """Extended source model
@@ -277,6 +287,8 @@ class SingleExtendedSource(FactorizedComponent):
             Initialize with the shape of a point source
         shifting: `bool`
             Whether or not a subpixel shift is added as optimization parameter
+        resizing : bool
+            Whether or not to change the size of the source box.
         boxsize: int or None
             Spatial size of the source box
         """
@@ -313,6 +325,7 @@ class SingleExtendedSource(FactorizedComponent):
             symmetric=False,
             min_grad=0,
             shifting=shifting,
+            resizing=resizing,
         )
 
         # find best-fit spectra for morph from init coadd
@@ -509,6 +522,7 @@ class MultiExtendedSource(CombinedComponent):
         flux_percentiles=None,
         thresh=1.0,
         shifting=False,
+        resizing=True,
         boxsize=None,
     ):
         """Create multi-component extended source.
@@ -534,6 +548,8 @@ class MultiExtendedSource(CombinedComponent):
             flux cutoff for morphology initialization.
         shifting: `bool`
             Whether or not a subpixel shift is added as optimization parameter
+        resizing : bool
+            Whether or not to change the size of the source box.
         boxsize: int or None
             Spatial size of the source box
         """
@@ -547,7 +563,9 @@ class MultiExtendedSource(CombinedComponent):
             observations = (observations,)
 
         # start off with regular ExtendedSource
-        source = ExtendedSource(model_frame, sky_coord, observations, thresh=thresh)
+        source = ExtendedSource(
+            model_frame, sky_coord, observations, thresh=thresh, boxsize=boxsize
+        )
         _, morphology = source.children
         morphs, boxes = self.init_morphs(morphology, flux_percentiles)
 
@@ -579,6 +597,7 @@ class MultiExtendedSource(CombinedComponent):
                 symmetric=False,
                 min_grad=0,
                 shifting=shifting,
+                resizing=resizing,
             )
             self.center = morphology.center
             component = FactorizedComponent(model_frame, spectrum, morphology)
@@ -641,6 +660,7 @@ def ExtendedSource(
     thresh=1.0,
     compact=False,
     shifting=False,
+    resizing=True,
     boxsize=None,
 ):
     """Create extended sources with either a single component or multiple components.
@@ -651,7 +671,12 @@ def ExtendedSource(
 
     if compact:
         return CompactExtendedSource(
-            model_frame, sky_coord, observations, shifting=shifting, boxsize=boxsize,
+            model_frame,
+            sky_coord,
+            observations,
+            shifting=shifting,
+            resizing=resizing,
+            boxsize=boxsize,
         )
     if K == 1:
         return SingleExtendedSource(
@@ -660,6 +685,7 @@ def ExtendedSource(
             observations,
             thresh=thresh,
             shifting=shifting,
+            resizing=resizing,
             boxsize=boxsize,
         )
     else:
@@ -671,5 +697,6 @@ def ExtendedSource(
             flux_percentiles=flux_percentiles,
             thresh=thresh,
             shifting=shifting,
+            resizing=resizing,
             boxsize=boxsize,
         )

--- a/scarlet/testing/deblend.py
+++ b/scarlet/testing/deblend.py
@@ -44,6 +44,7 @@ def deblend(data: Dict[str, np.ndarray], max_iter: int, e_rel: float):
         centers,
         observation,
         max_components=2,
+        min_components=1,
         min_snr=30,
         thresh=1,
         fallback=True,

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -59,7 +59,9 @@ class TestFactorizedComponent:
         # now with shift
         shift_loc = (0, 1, 0)
         shift = scarlet.Parameter(np.array(shift_loc[1:]), step=0.1, name="shift")
-        morphology = scarlet.ImageMorphology(frame, morph, bbox=box[1:], shift=shift)
+        morphology = scarlet.ImageMorphology(
+            frame, morph, bbox=box[1:], shifting=True, shift=shift
+        )
 
         component = scarlet.FactorizedComponent(frame, spectrum, morphology)
         model = component.get_model(frame=frame)


### PR DESCRIPTION
stabilize the morphology initialization at the faint/small side by making sure its at least as wide as the PSF