### PR TITLE
Spectrum initialization incorrect for strongly masked data

### DIFF
--- a/scarlet/initialization.py
+++ b/scarlet/initialization.py
@@ -590,4 +590,5 @@ def set_spectra_to_match(sources, observations):
 
     # enforce constraints
     for p in parameters:
-        p[:] = p.constraint(p, 0)
+        if p.constraint is not None:
+            p[:] = p.constraint(p, 0)

--- a/scarlet/initialization.py
+++ b/scarlet/initialization.py
@@ -565,13 +565,25 @@ def set_spectra_to_match(sources, observations):
         # solve the linear inverse problem of the amplitudes in every channel
         # given all the rendered morphologies
         # spectrum = (M^T Sigma^-1 M)^-1 M^T Sigma^-1 * im
-        spectra = np.empty((K, C))
+        spectra = np.zeros((K, C))
         for c in range(C):
             im = images[c].reshape(-1)
             w = weights[c].reshape(-1)
             m = morphs[:, c, :, :].reshape(K, -1)
-            covar = np.linalg.inv((m * w[None, :]) @ m.T)
-            spectra[:, c] = covar @ m @ (im * w)
+            mw = m * w[None, :]
+            # check if all components have nonzero flux in c.
+            # because of convolutions, flux can be outside of the box,
+            # so we need to compare weighted flu with unweighted flux,
+            # which is the same (up to a constant) for constant weights
+            # so we check if *most* of the flux is from pixels with non-zero weight
+            nonzero = np.sum(mw, axis=1) / np.sum(m, axis=1) / np.mean(w) > 0.1
+            nonzero = np.flatnonzero(nonzero)
+            if len(nonzero) == K:
+                covar = np.linalg.inv(mw @ m.T)
+                spectra[:, c] = covar @ m @ (im * w)
+            else:
+                covar = np.linalg.inv(mw[nonzero] @ m[nonzero].T)
+                spectra[nonzero, c] = covar @ m[nonzero] @ (im * w)
 
         for p, spectrum in zip(parameters, spectra):
             obs.renderer.map_channels(p)[:] = spectrum

--- a/scarlet/observation.py
+++ b/scarlet/observation.py
@@ -86,7 +86,7 @@ class Observation(Frame):
         # choose the renderer
         if renderer is None:
             if self.psf is model_frame.psf:
-                self.renderer = NullRenderer()
+                self.renderer = NullRenderer(self, model_frame)
             else:
                 assert self.psf is not None and model_frame.psf is not None
                 if self.wcs is model_frame.wcs:


### PR DESCRIPTION
As reported by #245,  non-sensical spectra arise from fitting data with strong masking, i.e. when sources are initialized in regions where one or more bands are largely unavailable. The counter-intuitive behavior is that the amplitude is very high in the masked bands, and essentially zero in the unmasked bands.

Two aspects contribute to this problem:
1. The initialization with the `set_spectra_to_match` method solves a linear problem that becomes ill-defined it a morphology vector has no (or almost no) overlap with the region of non-zero weights. If convolutions are in the forward path, this statement applies to the convolved morphology. In both cases, this yields a numerically unstable matrix inverse whenever the bulk of the source is in the masked region of a given band. The solver finds the spectrum amplitude for all components in each band, which means that a failure of one component in a band ruins the amplitude estimate for most/all components in that band (but other bands are unaffected). This is likely the cause for the counter-intuitive behavior. aa4ccd2 fixes this problem by only inverting the matrix for the sub-block of components that have sufficient non-zero product of morphology*weight.

2. The gradients used during the fit are quite volatile, which can lead to unexpected trajectories in parameter space. Here's an example of a `ExtendedSource` fit to data of a white source where the lower half of the reddest of 5 bands has weights=0: 

https://user-images.githubusercontent.com/1463403/124305843-a13ee200-db33-11eb-9b37-9ca9067b6169.mp4

After the initialization (which underestimates the amplitude in the reddest band and thus comes out in cyan), there's a strong red overcompensation. That's a really bad fit, so the model gets suppressed globally. When it returns it avoids the 5-band region in the top of the image. Because it has lower flux there, it cranks up the red amplitude to get the right intensity in that band (the bottom region will not object because it doesn't care about the red amplitude). In this noise-free data the problem eventually gets corrected but it takes a large number of iterations because there's no strong incentive in terms of the log-likelihood of the fit. This problem can only really be avoided by introducing more information to the model in terms of parameter constraints/priors. For instance, fitting the same data with a `PointSource` (or probably any other parameterized model) has no trouble getting the correct flat (=white) spectrum. Priors in the spectrum shape would likely help as well. 

The fits in #245 appear to use point-source models, so the fix for problem 1 above should be all that is needed. I write down problem 2 because it's pretty counter-intuitive, but not a bug in the code itself. It's a problem for the optimizer to find the correct values when any change in the non-parametric morphology yields a different mix of masked pixels in various bands, and any change of the spectrum will lead to changes in the morphology...

For completeness, the other two commit fix corner cases that I have triggered during testing the stuff above.
