### PR TITLE
Init fixes

### DIFF
--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -187,7 +187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we use a trivial `wcs` in this `Observation`, all coordinates are already in image pixels, otherwise RA/Dec pairs are expected as sky coordinates. Also:"
+    "Since we use a trivial `wcs` in this `Observation`, all coordinates are already in image pixels, otherwise RA/Dec pairs are expected as sky coordinates."
    ]
   },
   {
@@ -253,7 +253,7 @@
     "    else:\n",
     "         new_source = scarlet.ExtendedSource(model_frame, center, observation, compact=True)\n",
     "    sources.append(new_source)\n",
-    "    \n",
+    "\n",
     "for k, src in enumerate(sources):\n",
     "    print (f\"{k}: {src.__class__.__name__}\")"
    ]
@@ -280,7 +280,7 @@
    "source": [
     "## Create and Fit Model\n",
     "\n",
-    "The `Blend` class holds the list of sources and has the machinery to fit them to the given images. In this example the code is set to run for a maximum of 100 iterations, but will end early if the likelihood and all of the constraints converge."
+    "The `Blend` class holds the list of sources and has the machinery to fit them to the given images. In this example the code is set to run for a maximum of 100 iterations, but will end early if the likelihood and all the constraints converge."
    ]
   },
   {

--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -262,8 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These source are initialized independently, and their spectra, i.e. the amplitudes in every channel, assume that they are isolated.\n",
-    "We can make another sweep and determine their spectra so that their superposition best matches the observation. Above, this was done for use by the option `set_specta=True`. But we can call the linear solver directly:"
+    "These sources are initialized independently, with spectra taken from their peak position in the observations. We can make another sweep and determine their spectra such that their superposition best matches the observation. Above, this was done for use by the option `set_specta=True`. But we can call the linear solver directly:"
    ]
   },
   {
@@ -526,7 +525,7 @@
  "metadata": {
   "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -540,7 +539,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes problems identified in #282 and #283. The main change is that extended source initializations don't run the simple linear solver to get the best spectrum given their own morphology and the observation. Instead, we have been recommending using `set_spectrum_to_match`, which solves for the best-fit spectrum given _all_ morphologies in the scene. So, it's entirely sufficient, and probably safer in case of close blends, to initialize with the peak pixel.

As for #282, the linear solver now masks redundant components and throws an errors message when the problem occurs, so that the user can e.g. remove that component. This is probably the best we can do without knowing why the problem occurred in the first place.